### PR TITLE
Restore 2025 western theme page, move current site to /2026

### DIFF
--- a/app/2025/page.tsx
+++ b/app/2025/page.tsx
@@ -1,351 +1,237 @@
-"use client";
-import React, { useEffect, useState } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/ScrollTrigger";
-import Header from "@/components/Header";
-import HeroText from "@/components/HeroText";
-import AboutSection from "@/components/AboutSection";
-import ScheduleSign from "@/components/Signs/ScheduleSign";
-import Statistic from "@/components/Statistic";
-import FAQSign from "@/components/Signs/FAQSign";
-import SponsorSign from "@/components/Signs/SponsorSign";
-import SponsorCard from "@/components/SponsorCard";
-import FAQAccordian from "@/components/FAQAccordian";
-import ApplyButton from "@/components/ApplyButton";
-import Image from "next/image";
-import ActivityPreview from "@/components/Event/ActivityPreview";
-import BackgroundManager from "@/components/BackgroundManager";
-import { BackgroundScaleMode } from "@/components/BackgroundLayer";
-import { TypingProvider } from "@/context/TypingContext";
+"use client"
+import './styles.css';
+import React, { useEffect, useState } from 'react';
+import { IParallax, Parallax, ParallaxLayer } from '@react-spring/parallax'
+import Header2025 from '@/components/Header2025';
+import HeroText from '@/components/HeroText';
+import AboutSection from '@/components/AboutSection2025';
+import ScheduleSign from '@/components/Signs/ScheduleSign2025';
+import Statistic from '@/components/Statistic';
+import FAQSign from '@/components/Signs/FAQSign';
+import SponsorSign from '@/components/Signs/SponsorSign';
+import SponsorCard from '@/components/SponsorCard2025';
+import FAQAccordian from '@/components/FAQAccordian2025';
+import ApplyButton from '@/components/ApplyButton2025';
+import Image from 'next/image';
+import { useResize } from '@react-spring/web';
+import ActivityPreview from '@/components/Event/ActivityPreview2025';
+import { LAYER_OFFSETS, PAGES_BY_SCREEN, ScreenSize } from '@/utils/parallaxOffset';
 
 const sponsors = [
-  [
-    // XL logos
+  [ // XL logos
     {
-      name: "CAT",
+      name: 'CAT',
       logo: "/assets/sponsors/cat.png",
-      url: "https://www.caterpillar.com/",
+      url: 'https://www.caterpillar.com/'
     },
     {
-      name: "SFAB",
+      name: 'SFAB',
       logo: "/assets/sponsors/SFAB.png",
-      url: "https://www.purdue.edu/sao/Fundraising/SOGA%20and%20SFAB.html",
-    },
+      url: 'https://www.purdue.edu/sao/Fundraising/SOGA%20and%20SFAB.html'
+    }
   ],
-  [
-    // LG logos
+  [ // LG logos
   ],
-  [
-    // MD logos
+  [ // MD logos
     {
-      name: "Purdue CS",
+      name: 'Purdue CS',
       logo: "/assets/sponsors/PurdueCS.svg",
-      url: "https://www.cs.purdue.edu/",
+      url: 'https://www.cs.purdue.edu/'
     },
     {
-      name: "D.E. Shaw",
+      name: 'D.E. Shaw',
       logo: "/assets/sponsors/deshaw.png",
-      url: "https://www.deshaw.com/",
+      url: 'https://www.deshaw.com/'
     },
     {
-      name: "RCAC",
+      name: 'RCAC',
       logo: "/assets/sponsors/RCAC_Logo.png",
-      url: "https://www.rcac.purdue.edu/",
+      url: 'https://www.rcac.purdue.edu/'
     },
   ],
-  [
-    // SM logos
+  [ // SM logos
     {
-      name: "CoE",
+      name: 'CoE',
       logo: "/assets/sponsors/coe.svg",
-      url: "https://engineering.purdue.edu/Engr",
+      url: 'https://engineering.purdue.edu/Engr'
     },
     {
-      name: "Roboflow",
+      name: 'Roboflow',
       logo: "/assets/sponsors/roboflow.png",
-      url: "https://roboflow.com/",
+      url: 'https://roboflow.com/'
     },
     {
-      name: "Runpod",
+      name: 'Runpod',
       logo: "/assets/sponsors/runpod_color.png",
-      url: "https://www.runpod.io/",
+      url: 'https://www.runpod.io/'
     },
     {
-      name: "Purdue Innovates",
+      name: 'Purdue Innovates',
       logo: "/assets/sponsors/purdue_innovates.png",
-      url: "https://purdueinnovates.org/",
-    },
+      url: 'https://purdueinnovates.org/'
+    }
   ],
   [
     {
-      name: "Klaviyo",
+      name: 'Klaviyo',
       logo: "/assets/sponsors/klaviyo.png",
-      url: "https://www.klaviyo.com/",
+      url: 'https://www.klaviyo.com/'
     },
     {
-      name: "Blip",
+      name: 'Blip',
       logo: "/assets/sponsors/blip.png",
-      url: "https://www.blippayments.com/",
+      url: 'https://www.blippayments.com/'
     },
     {
-      name: "Sync",
+      name: 'Sync',
       logo: "/assets/sponsors/sync.png",
-      url: "https://sync.so/",
-    },
+      url: 'https://sync.so/'
+    }, 
     {
-      name: "Modal",
+      name: 'Modal',
       logo: "/assets/sponsors/modal.svg",
-      url: "https://modal.com/",
+      url: 'https://modal.com/'
     },
+
   ],
   [
     {
-      name: "Taco Bell",
+      name: 'Taco Bell',
       logo: "/assets/sponsors/TacoBell.svg",
-      url: "https://www.tacobell.com/",
+      url: 'https://www.tacobell.com/'
     },
     {
-      name: "Cartesia",
+      name: 'Cartesia',
       logo: "/assets/sponsors/cartesia.svg",
-      url: "https://www.cartesia.ai/",
+      url: 'https://www.cartesia.ai/'
     },
     {
-      name: "Warp",
+      name: 'Warp',
       logo: "/assets/sponsors/warp.png",
-      url: "https://www.warp.dev/",
+      url: 'https://www.warp.dev/'
     },
     {
-      name: "Wolfram",
+      name: 'Wolfram',
       logo: "/assets/sponsors/wolfram.png",
-      url: "https://www.wolfram.com/",
+      url: 'https://www.wolfram.com/'
     },
-  ],
+  ]
 ];
 
 const activities = [
   {
-    title: "Opening Ceremony",
-    startDate: "2026-01-23T19:00:00",
-    endDate: "2026-01-23T21:00:00",
-    location: "Frances A. Cordova Recreational Sports Center",
-    description: "Introduction to BoilerMake, event logistics, and ice breaker activities!",
+    title: 'Opening Ceremony',
+    startDate: "2025-02-21T19:00:00",
+    endDate: "2025-02-21T20:00:00",
+    location: 'Frances A. Cordova Recreational Sports Center',
+    description: 'Introduction to BoilerMake.'
   },
   {
-    title: "Arcade",
-    startDate: "2026-01-24T21:00:00",
-    endDate: "2026-01-24T23:00:00",
-    location: "Frances A. Cordova Recreational Sports Center",
-    description: "Hackers can take a break and enjoy some arcade games, eat some snacks, socialize, and win prizes!",
+    title: 'Hacking Starts',
+    startDate: "2025-02-21T20:00:00",
+    endDate: "2025-02-21T20:00:00",
+    location: 'Frances A. Cordova Recreational Sports Center',
+    description: 'Hackers can start coding.'
   },
   {
-    title: "Hacking Ends",
-    startDate: "2026-01-25T09:00:00",
-    location: "Frances A. Cordova Recreational Sports Center",
-    description: "Hackers finish up their projects and submit online for judging before the deadline. They have time to prepare presentations and demos for the judges.",
+    title: 'Carnival',
+    startDate: "2025-02-22T21:00:00",
+    endDate: "2025-02-23T00:00:00",
+    location: 'Frances A. Cordova Recreational Sports Center',
+    description: 'Event filled with fun games and activities.'
   },
   {
-    title: "Judging",
-    startDate: "2026-01-25T10:00:00",
-    endDate: "2026-01-25T11:00:00",
-    location: "Frances A. Cordova Recreational Sports Center",
-    description: "A first round of judging where hackers are judged based on their submitted projects by our panel of judges.",
+    title: 'Hacking Ends',
+    startDate: "2025-02-23T08:00:00",
+    endDate: "2025-02-23T08:00:00",
+    location: 'Frances A. Cordova Recreational Sports Center',
+    description: 'Hackers must stop coding.'
   },
   {
-    title: "Shark Tank",
-    startDate: "2026-01-25T13:30:00",
-    endDate: "2026-01-25T15:30:00",
-    location: "Frances A. Cordova Recreational Sports Center",
-    description: "The finalists present their projects to a panel of judges in a Shark Tank-style format for final evaluation. Awards and prizes are given out to the winners.",
+    title: 'Judging',
+    startDate: "2025-02-23T10:00:00",
+    endDate: "2025-02-23T14:00:00",
+    location: 'Frances A. Cordova Recreational Sports Center',
+    description: 'First round of judging (all submitted projects).'
   },
-];
+  {
+    title: 'Closing Ceremony',
+    startDate: "2025-02-23T14:15:00",
+    endDate: "2025-02-23T15:00:00",
+    location: 'Frances A. Cordova Recreational Sports Center',
+    description: 'Final round of judging and all prize winners announced.'
+  }
+]
 
 const questions = [
   {
-    question: "What is a Hackathon?",
-    answer:
-      "The BoilerMake hackathon is a 36-hour event where you can learn, build, and share a cool technology-based project! On top of your project work, you'll get free food, swag, and opportunities to win some of our $4,000 in prizes offered! We offer numerous events and activities as well to keep the fun going, and provide a platform to network with companies in the tech sector and other like-minded individuals from numerous backgrounds.",
+    question: 'What is a Hackathon?',
+    answer: "The BoilerMake hackathon is a 36-hour event where you can learn, build, and share a cool technology-based project! On top of your project work, you'll get free food, swag, and opportunities to win some of our $4,000 in prizes offered! We offer numerous events and activities as well to keep the fun going, and provide a platform to network with companies in the tech sector and other like-minded individuals from numerous backgrounds."
   },
   {
-    question:
-      "Who can attend and how much experience do I need to participate?",
-    answer:
-      "Any undergraduate university student age 18 or older from any school or major can attend BoilerMake! No experience or technical background is required to participate, and we have mentors on site to assist with any technical needs. We also have unique and enriching experiences available to more skilled hackers, with special technologies and tech talks offered.",
+    question: 'Who can attend and how much experience do I need to participate?',
+    answer: 'Any undergraduate university student age 18 or older from any school or major can attend BoilerMake! No experience or technical background is required to participate, and we have mentors on site to assist with any technical needs. We also have unique and enriching experiences available to more skilled hackers, with special technologies and tech talks offered.'
   },
   {
-    question: "How does the application process work?",
-    answer:
-      "Once applications open, try to submit as soon as possible, make sure to write thoughtful responses in the application, and provide a good resume you want recruiters to see — these are sent to tech companies! Once your application is submitted, you can add your team members through the Teams portal — applicants in a Team will be preferred. After you are accepted through one of our acceptance rounds, you are REQUIRED to RSVP to attend the event. If you are Waitlisted, you are REQUIRED to RSVP to the waitlist to have a good chance at getting a spot. More details will be sent out based on your situation.",
+    question: 'How does the application process work?',
+    answer: 'Once applications open, try to submit as soon as possible, make sure to write thoughtful responses in the application, and provide a good resume you want recruiters to see — these are sent to tech companies! Once your application is submitted, you can add your team members through the Teams portal — applicants in a Team will be preferred. After you are accepted through one of our acceptance rounds, you are REQUIRED to RSVP to attend the event. If you are Waitlisted, you are REQUIRED to RSVP to the waitlist to have a good chance at getting a spot. More details will be sent out based on your situation.'
   },
   {
-    question: "What projects can I make at BoilerMake?",
-    answer:
-      "You can build any project you want at BoilerMake! We have no strict project requirements, other than that it was built at the hackathon itself. Every year, we see a wide variety of technologies used and various applications for projects, and even see hardware-based projects — the possibilities are endless!",
+    question: 'What projects can I make at BoilerMake?',
+    answer: 'You can build any project you want at BoilerMake! We have no strict project requirements, other than that it was built at the hackathon itself. Every year, we see a wide variety of technologies used and various applications for projects, and even see hardware-based projects — the possibilities are endless!'
   },
   {
-    question: "Does BoilerMake offer travel reimbursements?",
-    answer:
-      "Unfortunately, BoilerMake is not able to offer travel reimbursements at this time to those attending from other universities. We do provide all meals while you are at the hackathon, and offer parking to those who need it. The BoilerMake hackathon venue will be open during the entire duration of the hackathon, and there are many nearby locations which can offer housing over the course of the two nights.",
-  },
+    question: 'Does BoilerMake offer travel reimbursements?',
+    answer: 'Unfortunately, BoilerMake is not able to offer travel reimbursements at this time to those attending from other universities. We do provide all meals while you are at the hackathon, and offer parking to those who need it. The BoilerMake hackathon venue will be open during the entire duration of the hackathon, and there are many nearby locations which can offer housing over the course of the two nights.'
+  }
 ];
 
-
 function App() {
+  const [screenSize, setScreenSize] = useState<ScreenSize>('lg');
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const parallaxRef = React.useRef<IParallax>(null);
   const [activeEventId, setActiveEventId] = useState<number>(0);
+  const { width, height } = useResize({
+    container: containerRef
+  });
   const [isLoaded, setIsLoaded] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
-  const [isUltraWide, setIsUltraWide] = useState(false);
-  // Initial positions for SSR/first render only
-  const [aboutCircleTop] = useState<string>("-20vh");
-  const [aboutCircleOpacity] = useState<number>(0.8);
-  const [faqCircleTop] = useState<string>("830vh");
-  const [faqCircleOpacity] = useState<number>(0.8);
 
   useEffect(() => {
+    const updateScreenSize = () => {
+      const width = window.innerWidth;
+      if (width < 640) setScreenSize('sm');
+      else if (width < 768) setScreenSize('md');
+      else if (width < 1024) setScreenSize('lg');
+      else if (width < 1280) setScreenSize('xl');
+      else setScreenSize('2xl');
+    };
+
+    updateScreenSize();
+    window.addEventListener('resize', updateScreenSize);
+    return () => window.removeEventListener('resize', updateScreenSize);
+  }, []);
+
+  useEffect(() => {
+    // Set loaded state after component mounts
     setIsLoaded(true);
 
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
+    // Check for scroll parameter in URL
+    const params = new URLSearchParams(window.location.search);
+    const scrollOffset = params.get('scroll');
 
-    const checkUltraWide = () => {
-      setIsUltraWide(window.innerWidth > 2559);
-    };
+    if (scrollOffset && parallaxRef.current && isLoaded) {
+      // Small delay to ensure parallax is fully initialized
+      setTimeout(() => {
+        // Remove the parameter from URL without refreshing the page
+        window.history.replaceState({}, '', '/2025');
+        // Scroll to the specified offset
+        parallaxRef.current?.scrollTo(parseFloat(scrollOffset));
+      }, 100);
+    }
+  }, [isLoaded]); // Add isLoaded to dependency array
 
-    checkMobile();
-    checkUltraWide();
-    window.addEventListener("resize", checkMobile);
-
-    return () => {
-      window.removeEventListener("resize", checkMobile);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    gsap.registerPlugin(ScrollTrigger);
-
-    // Scope to this component so cleanup is airtight
-    const ctx = gsap.context(() => {
-      const aboutCircle = document.querySelector('[data-layer-id="about-circle"]') as HTMLElement | null;
-      const faqCircle   = document.querySelector('[data-layer-id="faq-circle"]')   as HTMLElement | null;
-
-      // Smooth, monotonic scrubs; GSAP re-computes on address bar changes via refresh
-      // ABOUT: from -20vh to 230vh  → delta 250vh
-      if (aboutCircle) {
-        gsap.set(aboutCircle, { y: 0, willChange: "transform" });
-        gsap.to(aboutCircle, {
-          // convert the same vh delta to px each refresh
-          y: () => window.innerHeight * (230 - (-20)) / 100,
-          ease: "none",
-          scrollTrigger: {
-            trigger: document.body,
-            start: 0,                                        // 0vh
-            end: () => window.innerHeight * 2.5,            // 250vh
-            scrub: true,
-            fastScrollEnd: true,
-            invalidateOnRefresh: true
-          }
-        });
-      }
-
-      // FAQ: stop when circle's center aligns with "Escape Reality" heading center
-      if (faqCircle) {
-        gsap.set(faqCircle, { y: 0, willChange: "transform", force3D: true });
-
-        const faqSection = document.getElementById("faq");
-        const contact    = document.getElementById("contact");
-        // try to grab the heading inside #contact; fallback to the section itself
-        const heading    = (contact?.querySelector("h1") as HTMLElement) || contact!;
-
-        const pageY = (el: HTMLElement) => el.getBoundingClientRect().top + window.scrollY;
-
-        // small knobs:
-        const startOffsetPx = 0;    // begin moving exactly when #faq hits viewport top; raise if you want a later start
-        const nudgePx       = 0;    // positive = stop a bit higher than exact center; negative = a bit lower
-
-        const compute = () => {
-          const baseTopPx    = parseFloat(getComputedStyle(faqCircle).top); // circle's CSS baseline (no transform)
-          const circleRect   = faqCircle.getBoundingClientRect();
-          const circleHalf   = circleRect.height / 2;
-
-          const startPx = faqSection ? pageY(faqSection) + startOffsetPx : window.scrollY;
-
-          const headingRect      = heading.getBoundingClientRect();
-          const headingCenterPx  = pageY(heading) + headingRect.height / 2;
-
-          // distance we need to translate so circle center == heading center (+ nudge)
-          const desiredY = Math.max(
-            0,
-            headingCenterPx - (baseTopPx + circleHalf) - nudgePx
-          );
-
-          // scroll span == movement distance so scrub maps 1:1
-          const endPx = startPx + desiredY;
-
-          return { startPx, endPx, desiredY };
-        };
-
-        // Build tween with dynamic, refresh-aware endpoints
-        const tween = gsap.to(faqCircle, {
-          y: () => compute().desiredY,
-          ease: "none",
-          scrollTrigger: {
-            trigger: document.body,
-            start: () => compute().startPx,
-            end:   () => compute().endPx,
-            scrub: true,
-            fastScrollEnd: true,
-            invalidateOnRefresh: true,
-            onRefresh: self => self.scroll(self.scroll()),
-            markers: false
-          }
-        });
-
-        // Helps with iOS up-scroll/address bar quirks
-        ScrollTrigger.normalizeScroll(true);
-      }
-
-      // Make sure ScrollTrigger measures correctly after content/fonts load
-      requestAnimationFrame(() => ScrollTrigger.refresh());
-    });
-
-    return () => {
-      ctx.revert(); // kills tweens and ScrollTriggers created in this effect
-    };
-  }, []);
-
-  useEffect(() => {
-    // Run after hydration + next paint
-    const nudge = () => {
-      // Dispatch synthetic scroll/resize to observers
-      window.dispatchEvent(new Event("resize"));
-      window.dispatchEvent(new Event("scroll"));
-      // Tiny scroll jiggle to guarantee intersection recalculation
-      const x = window.scrollX,
-        y = window.scrollY;
-      window.scrollTo(x, y + 1);
-      window.scrollTo(x, y);
-    };
-
-    // Initial nudge
-    const t1 = setTimeout(nudge, 0);
-    // Nudge again after images/styles settle
-    const t2 = setTimeout(nudge, 250);
-
-    // Also nudge when page becomes visible (reloads from bfcache, etc.)
-    const onVis = () => {
-      if (document.visibilityState === "visible") {
-        nudge();
-      }
-    };
-    document.addEventListener("visibilitychange", onVis);
-
-    return () => {
-      clearTimeout(t1);
-      clearTimeout(t2);
-      document.removeEventListener("visibilitychange", onVis);
-    };
-  }, []);
+  // Helper function to get offset for a layer
+  const getOffset = (layerId: string) => LAYER_OFFSETS[layerId][screenSize];
 
   const handleEventClick = (id: number) => {
     if (id === activeEventId) {
@@ -355,815 +241,463 @@ function App() {
     }
   };
 
-  // Background layer configuration with responsive heights
-  const backgroundLayers = [
-    {
-      id: "solid-bg-color",
-      imageUrl: "/this/is/a/fake/image.png", // This will fail to load, showing fallback
-      zIndex: -100,
-      opacity: 1,
-      fallbackColor: "#2A2627", // This should show as the background color
-      priority: true, // Always load immediately
-    },
-    {
-      id: "background-comb",
-      imageUrl: "/images/bg-comb.svg",
-      position: "absolute" as const,
-      zIndex: -50,
-      opacity: 1,
-      top: 0,
-      blendMode: "normal",
-      useIntrinsicHeight: false,
-      height: "500vh",
-      width: "100%",
-      fallbackColor: "transparent",
-      priority: true,
-    },
-    {
-      id: "stars-left",
-      imageUrl: "/images/stars-left.png",
-      position: "absolute" as const,
-      zIndex: -50,
-      opacity: 0.8,
-      top: "80vh",
-      left: "-35%",
-      height: "30vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "stars-right",
-      imageUrl: "/images/stars-right.png",
-      position: "absolute" as const,
-      zIndex: -99,
-      opacity: 0.8,
-      top: "60vh", // A bit higher than stars-left (80vh)
-      left: "35%", // Positioned on the right side (100% + 35% overhang = 135%)
-      height: "30vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "about-circle",
-      imageUrl: "/images/about-circle.png",
-      position: "absolute" as const,
-      zIndex: -80,
-      opacity: aboutCircleOpacity,
-      top: aboutCircleTop,
-      left: "0%",
-      height: "150vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "stars-about",
-      imageUrl: "/images/stars-about.png",
-      position: "absolute" as const,
-      zIndex: -81,
-      opacity: 0.8, // Increase visibility
-      top: "255vh", // Start at the top of the viewport
-      left: "25%",
-      height: "30vh", // Covers the viewport while scrolling
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true,
-    },
-    {
-      id: "about-accent",
-      imageUrl: isUltraWide ? "/this/is/fake" : "/images/about-accent.svg",
-      position: "absolute" as const,
-      zIndex: -70,
-      opacity: 1,
-      top: "250vh",
-      left: "0%",
-      height: "30vh",
-      width: "100%",
-      scaleMode: "fill" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-    {
-      id: "stars-schedule",
-      imageUrl: "/images/stars-schedule.png",
-      position: "absolute" as const,
-      zIndex: -51,
-      opacity: 0.8,
-      top: "400vh", // A bit higher than stars-left (80vh)
-      left: "-30%", // Positioned on the right side (100% + 35% overhang = 135%)
-      height: "40vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "corridor-1",
-      imageUrl: "/images/corridor-1.png",
-      position: "absolute" as const,
-      zIndex: -50,
-      opacity: 1,
-      top: "440vh",
-      left: "calc(50% - 125px)",
-      width: "250px",
-      height: "210vh",
-      scaleMode: "fill" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      useIntrinsicHeight: false,
-    },
-    {
-      id: "ringed-red-planet",
-      imageUrl: "/images/ringed-red-planet.png",
-      position: "absolute" as const,
-      zIndex: -50,
-      opacity: 1,
-      top: "470vh",
-      left: "75vw",
-      width: "25vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-    {
-      id: "schedule-grid",
-      imageUrl: "/images/schedule-grid.png",
-      position: "absolute" as const,
-      zIndex: -70,
-      opacity: 1,
-      top: "470vh",
-      left: "0%",
-      width: "100%",
-      height: "260vh",
-      useIntrinsicHeight: false,
-      scaleMode: "cover" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-    {
-      id: "white-star",
-      imageUrl: "/images/white-star.png",
-      position: "absolute" as const,
-      zIndex: -40,
-      opacity: 1,
-      top: "525vh",
-      left: "20vw",
-      width: "20vw",
-      height: "20vh",
-      scaleMode: "fill" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-    {
-      id: "blue-red-planet",
-      imageUrl: "/images/blue-red-planet.png",
-      position: "absolute" as const,
-      zIndex: -40,
-      opacity: 1,
-      top: "600vh",
-      left: "60vw",
-      width: "20vw",
-      height: "20vh",
-      scaleMode: "fill" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-    {
-      id: "faq-gradient",
-      imageUrl: "/images/faq-gradient.png",
-      position: "absolute" as const,
-      zIndex: -50,
-      opacity: 1,
-      top: "700vh",
-      left: "0%",
-      width: "100vw",
-      height: "1200vh",
-      useIntrinsicHeight: false,
-      scaleMode: "fill" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true,
-    },
-    {
-      id: "stars-faq",
-      imageUrl: "/images/stars-faq.png",
-      position: "absolute" as const,
-      zIndex: 0,
-      opacity: 0.8,
-      top: "830vh", // A bit higher than stars-left (80vh)
-      left: "-35%", // Positioned on the right side (100% + 35% overhang = 135%)
-      height: "40vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "faq-circle",
-      imageUrl: "/images/faq-circle.png",
-      position: "absolute" as const,
-      zIndex: -99,
-      opacity: faqCircleOpacity,
-      top: faqCircleTop,
-      left: "0%",
-      height: "150vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "stars-faq2",
-      imageUrl: "/images/stars-faq2.png",
-      position: "absolute" as const,
-      zIndex: 0,
-      opacity: 0.8,
-      top: "960vh", // A bit higher than stars-left (80vh)
-      left: "35%", // Positioned on the right side (100% + 35% overhang = 135%)
-      height: "40vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "faq-accent",
-      imageUrl: "/images/faq_paths.svg",
-      position: "absolute" as const,
-      zIndex: -30,
-      opacity: 1,
-      top: "840vh",
-      left: "0vw",
-      width: "100vw",
-      height: "20vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-    {
-      id: "stars-sponsors",
-      imageUrl: "/images/stars-sponsors.png",
-      position: "absolute" as const,
-      zIndex: 0,
-      opacity: 0.8, // Increase visibility
-      top: "1040vh", // Start at the top of the viewport
-      left: "35%",
-      height: "40vh", // Covers the viewport while scrolling
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true,
-    },
-    // {
-    //   id: "planet-1",
-    //   imageUrl: "/images/planet1.png",
-    //   position: "absolute" as const,
-    //   zIndex: -39,
-    //   opacity: 1,
-    //   top: "1506vh",
-    //   left: "40vw",
-    //   // width: "100vw",
-    //   height: "20vw",
-    //   scaleMode: "contain" as BackgroundScaleMode,
-    //   blendMode: "normal",
-    //   fallbackColor: "transparent",
-    // },
-    // {
-    //   id: "planet2",
-    //   imageUrl: "/images/planet2.png",
-    //   position: "absolute" as const,
-    //   zIndex: -39,
-    //   opacity: 1,
-    //   top: "1415vh",
-    //   left: "47vw",
-    //   // width: "100vw",
-    //   height: "20vh",
-    //   scaleMode: "contain" as BackgroundScaleMode,
-    //   blendMode: "normal",
-    //   fallbackColor: "transparent",
-    // },
-    // {
-    //   id: "planet3",
-    //   imageUrl: "/images/planet3.png",
-    //   position: "absolute" as const,
-    //   zIndex: -39,
-    //   opacity: 1,
-    //   top: "1480vh",
-    //   left: "-40vw",
-    //   // width: "100vw",
-    //   height: "20vh",
-    //   scaleMode: "contain" as BackgroundScaleMode,
-    //   blendMode: "normal",
-    //   fallbackColor: "transparent",
-    // },
-    // {
-    //   id: "planet4",
-    //   imageUrl: "/images/planet4.png",
-    //   position: "absolute" as const,
-    //   zIndex: -39,
-    //   opacity: 1,
-    //   top: "1450vh",
-    //   left: "1vw",
-    //   // width: "100vw",
-    //   height: "20vh",
-    //   scaleMode: "contain" as BackgroundScaleMode,
-    //   blendMode: "normal",
-    //   fallbackColor: "transparent",
-    // },
-    // {
-    //   id: "ringed-planet",
-    //   imageUrl: "/images/ring-planet.png",
-    //   position: "absolute" as const,
-    //   zIndex: -39,
-    //   opacity: 1,
-    //   top: "1350vh",
-    //   left: "-30vw",
-    //   height: "20vh",
-    //   scaleMode: "contain" as BackgroundScaleMode,
-    //   blendMode: "normal",
-    //   fallbackColor: "transparent",
-    // },
-    {
-      id: "orbits",
-      imageUrl: "/images/solar_sys.svg",
-      position: "absolute" as const,
-      zIndex: -40,
-      opacity: 1,
-      top: "1350vh",
-      left: "0vw",
-      width: "100vw",
-      height: "200vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-    {
-      id: "stars-message",
-      imageUrl: "/images/stars-faq.png",
-      position: "absolute" as const,
-      zIndex: 0,
-      opacity: 0.8,
-      top: "1600vh", // A bit higher than stars-left (80vh)
-      left: "-35%", // Positioned on the right side (100% + 35% overhang = 135%)
-      height: "40vh",
-      scaleMode: "contain" as BackgroundScaleMode,
-      backgroundPosition: "center",
-      blendMode: "normal",
-      fallbackColor: "transparent",
-      priority: true, // Always load immediately
-    },
-    {
-      id: "footer-accent",
-      imageUrl: "/images/footer-accent-high-res.png",
-      position: "absolute" as const,
-      zIndex: -80,
-      opacity: 1,
-      top: "1630vh",
-      left: "-40vw",
-      width: "150vw",
-      height: "120vh",
-      useIntrinsicHeight: false,
-      scaleMode: "fill" as BackgroundScaleMode,
-      blendMode: "normal",
-      fallbackColor: "transparent",
-    },
-  ];
+  const activity_vertical_offset: { [key: string]: string } = {
+    'activity1': "top-[5%] sm:top-[7%] md:top-[13%] lg:top-[11%] xl:top-[10%]",
+    'activity2': "top-[7%] sm:top-[9%] md:top-[14%] lg:top-[10%] xl:top-[12%]",
+    'activity3': "top-[15%] sm:top-[17%] md:top-[25%] lg:top-[35%] xl:top-[35%]",
+    'activity4': "top-[20%] sm:top-[19%] md:top-[32%] lg:top-[40%] xl:top-[45%]", // change this one
+    'activity5': "top-[42%] sm:top-[42%] md:top-[65%] lg:top-[80%] xl:top-[70%]", // change this one
+    'activity6': "top-[50%] sm:top-[50%] md:top-[80%] lg:top-[85%] xl:top-[95%]",
+  }
 
   return (
-    <TypingProvider>
-      <>
-        <link
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-          rel="stylesheet"
-        />
-        <div className="App font-dosis">
-          {/* Background Manager - replaces parallax background system */}
-          <BackgroundManager
-            layers={backgroundLayers}
-            globalFallbackColor="#C5E1E6"
-          />
+    <div className='App font-dosis page-2025' ref={containerRef}>
+      <Header2025 parallaxRef={parallaxRef} screenSize={screenSize} />
+      <Parallax ref={parallaxRef} pages={PAGES_BY_SCREEN[screenSize]} style={{ top: '0', left: '0' }} className="animation" key={screenSize}>
 
-          {/* Header - updated to work without parallax */}
-          <Header />
+        <ParallaxLayer offset={getOffset('about-background')} speed={0}>
+          <div id="about-background"></div>
+        </ParallaxLayer>
 
-          {/* Main content container with CSS Grid layout */}
-          <main
-            className="w-full main-content"
-            style={{ height: "1900vh", overflow: "hidden" }}
-          >
-            {/* Hero Section */}
-            <section id="hero" className="hero-section">
-              <div
-                className="hero-content "
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  textAlign: "center",
-                  width: "100%",
-                }}
-              >
-                <div className="hero-text">
-                  <h2
-                    className="text-center mb-6"
-                    style={{
-                      fontFamily: "var(--font-futura-cyrillic)",
-                      fontWeight: 100,
-                      fontSize: "clamp(18px, 3.5vw, 28px)",
-                      lineHeight: "100%",
-                      letterSpacing: "0.1em",
-                      color: "#FFFFFF",
-                      textAlign: "center",
-                      width: "100%",
-                      marginLeft: "auto",
-                      marginRight: "auto",
-                      filter: "drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))",
-                    }}
-                  >
-                    23 - 25 January 2026
-                    <span
-                      className="text-white"
-                      style={{ animation: "blink 1s step-end infinite" }}
-                    >
-                      _
-                    </span>
-                  </h2>
-                  <h1
-                    className="text-center mb-12"
-                    style={{
-                      fontFamily: "var(--font-disket-mono)",
-                      fontWeight: 400,
-                      fontSize: "clamp(32px, 8vw, 80px)",
-                      lineHeight: "100%",
-                      letterSpacing: "0.1em",
-                      color: "#FFE958",
-                      textShadow: "0px 0px 15px #FFDE00",
-                    }}
-                  >
-                    {" "}
-                    BOILERMAKE XIII{" "}
+        <ParallaxLayer offset={getOffset('hero')} speed={0.25}>
+          <div className="animation_layer parallax" id="hero"></div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('cliff')} speed={0.25}>
+          <div id='cliff'>
+            <Image
+              src="/images/cliffside.png"
+              alt="Cliff"
+              height={0}
+              width={0}
+              sizes='100vh'
+              className='w-full h-full object-cover'
+            />
+          </div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('hero-text')} speed={0.25}>
+          <div className="animation_layer parallax">
+            <div className="flex justify-end items-center p-4 sm:p-4 md:p-8 lg:p-16 xl:p-16">
+              <div className="text-right">
+                <div className="container mx-auto text-white">
+                  <h1 className="text-2xl sm:text-3xl md:text-5xl lg:text-7xl xl:text-8xl font-arvo font-bold">
+                    BOILERMAKE
                   </h1>
-                  <link
-                    rel="icon"
-                    href="assets/favicon.ico"
-                    type="image/x-icon"
-                  />
-                </div>
-                <div
-                  className="hero-buttons"
-                  style={{ 
-                    display: "flex",
-                    flexDirection: "row",
-                    gap: "1.5rem",
-                    justifyContent: "center",
-                    alignItems: "center",
-                    flexWrap: "wrap"
-                  }}
-                >
-                  <ApplyButton
-                    text="APPLY NOW!"
-                    link="https://boilermake-apply.web.app"
-                    size="large"
-                    variant="hero"
-                    className="mr-0"
-                  />
-                  <ApplyButton
-                    text="INTEREST FORM"
-                    link="https://docs.google.com/forms/d/e/1FAIpQLScaVyVFmm3Jwn1225SjUPCInKD9-MLZhxIRtQT8o4y1HAxs_g/viewform"
-                    size="large"
-                    variant="hero"
-                    className="mr-0"
-                  />
-                  <ApplyButton
-                    text="MENTOR FORM"
-                    link="https://docs.google.com/forms/d/e/1FAIpQLScmpc_zMGpQGUZy5vFkCTbkh-3oG5WMKx1eDES1ziDDSOqA4w/viewform"
-                    size="large"
-                    variant="hero"
-                    className="mr-0"
-                  />
-                </div>
-              </div>
-            </section>
-            {/* About Section */}
-            <section
-              id="about"
-              className="w-[80vw] lg:w-[60vw] flex items-center justify-center absolute"
-              style={{ top: "270vh" }}
-            >
-              <AboutSection />
-            </section>
-
-            {/* Schedule Section */}
-            <section
-              id="schedule"
-              className="w-full flex items-center justify-center absolute"
-              style={{ top: "410vh", paddingTop: "8rem" }}
-            >
-              <div className="w-full max-w-7xl mx-auto px-4">
-                <div
-                  className="text-center absolute left-1/2 -translate-x-1/2 z-10 pointer-events-none"
-                  style={{ top: "8rem" }}
-                >
-                  <div
-                    style={{
-                      fontFamily: "var(--font-disket-mono)",
-                      fontWeight: 400,
-                      fontSize: "clamp(32px, 8vw, 60px)",
-                      lineHeight: "100%",
-                      letterSpacing: "0.1em",
-                      color: "#FFE958",
-                      textShadow: "0px 0px 15px #FFDE00",
-                    }}
-                  >
-                    Schedule
-                    <span style={{ animation: "blink 1s infinite" }}>_</span>
-                  </div>
-                </div>
-
-                <div
-                  className="schedule-activities w-full relative mt-12 md:mt-32"
-                  style={{ marginTop: "12rem" }}
-                >
-                  {activities.map((activity, index) => {
-                    const isLeft = index % 2 === 0;
-                    return (
-                      <div
-                        key={`activity${index + 1}`}
-                        className={`
-                          absolute
-                          transition-transform duration-500
-                            ${
-                              isLeft
-                                ? "left-0 -translate-x-[-2%] md:-translate-x-[-5%] lg:-translate-x-[-3%] xl:-translate-x-[1%] min-[1340px]:-translate-x-[6%] min-[1400px]:-translate-x-[10%] min-[1470px]:-translate-x-[17%] 2xl:-translate-x-[20%]"
-                                : "right-0 translate-x-[-2%] md:translate-x-[-6%] lg:translate-x-[-3%] xl:translate-x-[1%] min-[1340px]:translate-x-[5%] min-[1400px]:translate-x-[10%] min-[1470px]:translate-x-[17%] 2xl:translate-x-[20%]"
-                            }
-                        `}
-                        style={{
-                          top: `${index * 33}vh`,
-                        }}
-                      >
-                        <ActivityPreview
-                          title={activity.title}
-                          startDate={activity.startDate}
-                          endDate={activity.endDate || ""}
-                          location={activity.location}
-                          description={activity.description}
-                          isActive={activeEventId === index + 1}
-                          onEventClick={() => handleEventClick(index + 1)}
-                          size="large"
-                          popup="left"
-                          align={isLeft ? "left" : "right"}
-                          activityId={index + 1}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            </section>
-
-            {/* FAQ Section */}
-            <section
-              id="faq"
-              className="w-full flex items-start justify-center absolute overflow-x-hidden"
-              style={{
-                top: "840vh",
-                paddingTop: "8rem",
-                paddingBottom: "8rem",
-              }}
-            >
-              {/* Absolute header like the others */}
-              <div
-                className="text-center absolute left-1/2 -translate-x-1/2 z-[100] pointer-events-none"
-                style={{ top: "8rem" }}
-              >
-                <div
-                  style={{
-                    fontFamily: "var(--font-disket-mono)",
-                    fontWeight: 400,
-                    fontSize: "clamp(32px, 8vw, 60px)",
-                    lineHeight: "100%",
-                    letterSpacing: "0.1em",
-                    color: "#FFE958",
-                    textShadow: "0px 0px 15px #FFDE00",
-                  }}
-                >
-                  FAQ<span style={{ animation: "blink 1s infinite" }}>_</span>
-                </div>
-              </div>
-
-              {/* Actual accordion content */}
-              <div
-                className="faq-sign w-full flex justify-center pb-8 overflow-x-hidden"
-                style={{ marginTop: "12rem" }}
-              >
-                <FAQAccordian questions={questions} />
-              </div>
-            </section>
-
-{/* Sponsors Section */}
-            <section
-              id="sponsors"
-              className="absolute flex flex-col items-center justify-center py-20 px-8 w-full"
-              style={{ top: "1050vh" }}
-            >
-              {/* Main Content Container - All content centered vertically */}
-              <div className="flex flex-col items-center justify-center gap-12 max-w-4xl">
-                {/* Message text */}
-                <h1
-                  className="text-center"
-                  style={{
-                    fontFamily: "var(--font-disket-mono)",
-                    fontWeight: 400,
-                    fontSize: "clamp(32px, 8vw, 60px)",
-                    lineHeight: "100%",
-                    letterSpacing: "0.1em",
-                    color: "#FFE958",
-                    textShadow: "0px 0px 15px #FFDE00",
-                  }}
-                >
-                  SPONSORS
-                  <span style={{ animation: "blink 1s infinite" }}>_</span>
-                </h1>
-
-                  <h2
-                    className="text-center mb-6"
-                    style={{
-                      
-                      fontWeight: 400,
-                      fontSize: "clamp(18px, 3.5vw, 28px)",
-                      lineHeight: "100%",
-                      letterSpacing: "0.1em",
-                      textAlign: "center",
-                      width: "100%",
-                      marginLeft: "auto",
-                      marginRight: "auto",
-                      filter: "drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))",
-                      fontFamily: "var(--font-disket-mono)",
-                      color: "#FFE958",
-                      textShadow: "0px 0px 15px #FFDE00",
-                    }}
-                  >
-                    [coming soon]
-                    <span
-                      className="text-white"
-                      // style={{ animation: "blink 1s step-end infinite" }}
-                    >
-                      {/* _ */}
-                    </span>
+                  <h2 className="text-[100px] md:text-[200px] font-arvo leading-none font-extrabold">
+                    XII
                   </h2>
-                {/* Button */}
-                <a
-                  // href="https://docs.google.com/forms/d/e/1FAIpQLScaVyVFmm3Jwn1225SjUPCInKD9-MLZhxIRtQT8o4y1HAxs_g/viewform"
-                  href="/past"
-                  className="inline-block px-12 py-4 border-2 border-white text-white uppercase tracking-wider transition-all duration-300 hover:bg-black/20"
-                  style={{
-                    fontFamily: "var(--font-futura-cyrillic)",
-                    fontWeight: 500,
-                    fontSize: "clamp(14px, 2vw, 18px)",
-                    letterSpacing: "0.15em",
-                  }}
-                >
-                  <span
-                    style={{
-                      borderBottom: "2px solid #FFFFFF",
-                      paddingBottom: "4px",
-                    }}
-                  >
-                    IN THE PAST
-                  </span>
-                </a>
+                  <p className="text-xl md:text-3xl font-body font-extrabold leading-none mb-4">
+                    2/21 - 2/23
+                  </p>
+                </div>
               </div>
-            </section>
+            </div>
+          </div>
+        </ParallaxLayer>
 
-            {/* Contact/Message Section */}
-            <section
-              id="contact"
-              className="absolute flex flex-col items-center justify-center py-20 px-8 w-full"
-              style={{ top: "1540vh" }}
+        <ParallaxLayer offset={getOffset('apply')} speed={0.25} style={{ zIndex: 10 }}>
+          <div className="flex justify-end items-center p-4 sm:p-4 md:p-8 lg:p-16 xl:p-16">
+            <div className="text-right">
+              <div className="container mx-auto">
+                <div className='sm:pt-[12rem] md:pt-[12rem] lg:pt-[22rem] xl:pt-[22rem]'>
+                  <ApplyButton text="Apply Now!" link='https://boilermake-apply.web.app' size={screenSize === 'sm' ? 'medium' : screenSize === 'md' ? 'medium' : screenSize === 'lg' ? 'large' : screenSize === 'xl' ? 'large' : 'large'} />
+                  <div className="h-4"></div>
+                  <ApplyButton text="Mentor Interest Form" link='https://forms.gle/Vdhhjfmhg1v6XuTG9' size={screenSize === 'sm' ? 'medium' : screenSize === 'md' ? 'medium' : screenSize === 'lg' ? 'large' : screenSize === 'xl' ? 'large' : 'large'} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('sun')} speed={0.35}>
+          <div className="animation_layer parallax" id="sun"></div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('cloud2')} speed={0.3}>
+          <div className="animation_layer parallax" id="cloud2"></div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('cloud4')} speed={0.25}>
+          <div className="animation_layer parallax" id="cloud4"></div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('cloud5')} speed={0.1}>
+          <div className="animation_layer parallax" id="cloud5"></div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('cloud3')} speed={0.4}>
+          <div className="animation_layer parallax" id="cloud3"></div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('cloud1')} speed={0.3}>
+          <div className="animation_layer parallax" id="cloud1"></div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('mini-cloud-left')} speed={0.3}>
+          <div className='lg:mt-[175px] xl:mt-[-60px]'>
+            <div className="animation_layer parallax" id="mini-cloud-left"></div>
+          </div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('mini-cloud-right')} speed={0.3}>
+          <div className="animation_layer parallax" id="mini-cloud-right"></div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('stat1')} speed={0.1}>
+          <div id='stat1' className='pt-16 sm:pt-0'>
+            <Statistic statistic='9' variable='Universities Represented' />
+          </div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('stat2')} speed={0.1}>
+          <div id='stat2' className='pt-8 sm:pt-0'>
+            <Statistic statistic='70' variable='Project Submissions' />
+          </div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('stat3')} speed={0.1}>
+          <div id='stat3'>
+            <Statistic statistic='$4k' variable='In Prizes' />
+          </div>
+        </ParallaxLayer>
+
+        {/* Tumbleweed */}
+        <ParallaxLayer offset={getOffset('tumbleweed')} speed={0} style={{ zIndex: 15, pointerEvents: 'none' }}>
+          <div className="absolute animate-tumble">
+            <Image
+              src="/images/tumbleweed.png"
+              alt="Tumbleweed"
+              width={200}
+              height={200}
+              className="w-[100px] h-[100px] sm:w-[150px] sm:h-[150px] md:w-[175px] md:h-[175px] lg:w-[200px] lg:h-[200px] animate-[tumble_8s_linear_infinite]"
+              priority
+            />
+          </div>
+        </ParallaxLayer>
+
+        {/* Background layer for FAQ */}
+        <ParallaxLayer offset={getOffset('faq-background')} speed={0}>
+          <div id="faq" className="h-full w-full grid grid-cols-3 gap-8 p-12">
+            {/* Empty space matching sign width */}
+            <div className="col-span-1"></div>
+            {/* Empty space for accordion */}
+            <div className="col-span-2"></div>
+          </div>
+        </ParallaxLayer>
+
+        {/* Floating accordion layer */}
+        <ParallaxLayer offset={getOffset('faq-sign')} speed={0} style={{ zIndex: 10 }}>
+          <div className="h-full w-full grid grid-cols-3 gap-8 p-12">
+            {/* First Column: FAQSign (1/3 of the screen) */}
+            <div className="col-span-1 flex justify-center items-center h-[500px]">
+              <FAQSign />
+            </div>
+            {/* Empty space for accordion */}
+            <div className="col-span-2"></div>
+          </div>
+        </ParallaxLayer>
+
+        {/* Floating accordion layer */}
+        <ParallaxLayer offset={getOffset('faq-accordion')} speed={0} style={{ zIndex: 50 }}>
+          <div className="h-full w-full grid grid-cols-3 gap-8 p-12">
+            {/* Empty space matching sign width */}
+            <div className="col-span-1"></div>
+            {/* Accordion floating above */}
+            <div className="col-span-2 pt-20 sm:pt-24 md:pt-28 lg:pt-32 xl:pt-36">
+              <FAQAccordian questions={questions} />
+            </div>
+          </div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('schedule-background')} speed={0}>
+          <div id="schedule" className='h-full w-full'>
+          </div>
+        </ParallaxLayer>
+
+        {/* Add tents layer */}
+        {/* <ParallaxLayer offset={getOffset('tents')} speed={0} style={{ zIndex: 20, pointerEvents: 'none' }}>
+          <div className="absolute left-6 sm:left-8 lg:left-16">
+            <Image
+              src="/images/tents.png"
+              alt="Tents"
+              width={50}
+              height={50}
+              className="w-[150px] h-[150px] sm:w-[200px] sm:h-[200px] md:w-[275px] md:h-[275px] lg:w-[350px] lg:h-[350px]"
+              priority
+            />
+          </div>
+        </ParallaxLayer> */}
+
+        <ParallaxLayer offset={getOffset('windyroad')} speed={0}>
+          <div className="relative h-[600px] md:h-[800px] lg:h-[1000px] xl:h-[1200px] w-full">
+            <Image
+              src="/images/windyroad.png"
+              alt="Road"
+              fill
+            />
+          </div>
+        </ParallaxLayer>
+
+        <ParallaxLayer offset={getOffset('schedule-section')} speed={0} style={{ zIndex: 10 }}>
+          {/* Schedule Sign */}
+          <div id="schedule-sign" className='h-full w-full'>
+            <div className='w-1/3 h-1/3'>
+              <ScheduleSign />
+            </div>
+          </div>
+
+          {/* Tents */}
+          <div className="absolute left-6 top-[30%] sm:left-8 lg:left-16 sm:top-[35%] md:top-[45%] lg:top-[60%] z-10">
+            <Image
+              src="/images/tents.png"
+              alt="Tents"
+              width={50}
+              height={50}
+              className="w-[150px] h-[150px] sm:w-[200px] sm:h-[200px] md:w-[275px] md:h-[275px] lg:w-[350px] lg:h-[350px]"
+              priority
+            />
+          </div>
+
+          {/* Activities */}
+          {activities.map((activity, index) => (
+            <div
+              key={`activity${index + 1}`}
+              id={`activity${index + 1}`}
+              className={`absolute ${activity_vertical_offset[`activity${index + 1}`]}`}
             >
-              {/* Main Content Container - All content centered vertically */}
-              <div className="flex flex-col items-center justify-center gap-12 max-w-4xl">
-                {/* Message text */}
-                <h1
-                  className="text-center"
-                  style={{
-                    fontFamily: "var(--font-disket-mono)",
-                    fontWeight: 400,
-                    fontSize: "clamp(32px, 8vw, 60px)",
-                    lineHeight: "100%",
-                    letterSpacing: "0.1em",
-                    color: "#FFE958",
-                    textShadow: "0px 0px 15px #FFDE00",
-                  }}
-                >
-                  Escape Reality
-                  <span style={{ animation: "blink 1s infinite" }}>_</span>
-                </h1>
+              <ActivityPreview
+                title={activity.title}
+                startDate={activity.startDate}
+                endDate={activity.endDate}
+                location={activity.location}
+                description={activity.description}
+                isActive={activeEventId === index + 1}
+                onEventClick={() => handleEventClick(index + 1)}
+                size={index < 2 ? 'small' : index < 4 ? 'medium' : index < 5 ? 'large' : 'xlarge'}
+                popup={(index === 2 || index === 5) ? 'right' : 'left'}
+              />
+            </div>
+          ))}
+        </ParallaxLayer>
 
-                {/* Button */}
-                <a
-                  // href="https://docs.google.com/forms/d/e/1FAIpQLScaVyVFmm3Jwn1225SjUPCInKD9-MLZhxIRtQT8o4y1HAxs_g/viewform"
-                  href="https://boilermake-apply.web.app"
-                  className="inline-block px-12 py-4 border-2 border-white text-white uppercase tracking-wider transition-all duration-300 hover:bg-black/20"
-                  style={{
-                    fontFamily: "var(--font-futura-cyrillic)",
-                    fontWeight: 500,
-                    fontSize: "clamp(14px, 2vw, 18px)",
-                    letterSpacing: "0.15em",
-                  }}
-                >
-                  <span
-                    style={{
-                      borderBottom: "2px solid #FFFFFF",
-                      paddingBottom: "4px",
-                    }}
+        {/* Birds near About section */}
+        <ParallaxLayer offset={getOffset('birds-about')} speed={0}>
+          <div className="absolute w-full left-[80%] top-[5%] sm:top-[0] md:top-[10%]">
+            <Image
+              src="/images/bird1.png"
+              alt="Bird 1"
+              width={65}
+              height={65}
+              className="absolute w-[65px] h-[65px] animate-[float_3s_ease-in-out_infinite]"
+              style={{ left: '0', top: '0' }}
+            />
+            <Image
+              src="/images/bird2.png"
+              alt="Bird 2"
+              width={65}
+              height={65}
+              className="absolute  w-[65px] h-[65px] animate-[float_3s_ease-in-out_infinite]"
+              style={{ left: '-10px', top: '40px', animationDelay: '0.5s' }}
+            />
+            <Image
+              src="/images/bird3.png"
+              alt="Bird 3"
+              width={65}
+              height={65}
+              className="absolute w-[65px] h-[65px] animate-[float_3s_ease-in-out_infinite]"
+              style={{ left: '50px', top: '20px', animationDelay: '1s' }}
+            />
+          </div>
+        </ParallaxLayer>
+
+        {/* Birds near Schedule section */}
+        <ParallaxLayer offset={getOffset('birds-schedule')} speed={0}>
+          <div className="absolute w-full left-[27%] top-[-7%] sm:top-[-4%] md:top-[10%]">
+            <Image
+              src="/images/bird2.png"
+              alt="Bird 2"
+              width={65}
+              height={65}
+              className="absolute w-[65px] h-[65px] animate-[float-flipped_3s_ease-in-out_infinite]"
+              style={{ left: '50px', top: '15px', animationDelay: '0.8s' }}
+            />
+            <Image
+              src="/images/bird1.png"
+              alt="Bird 1"
+              width={65}
+              height={65}
+              className="absolute w-[65px] h-[65px] animate-[float-flipped_3s_ease-in-out_infinite]"
+              style={{ left: '15px', top: '0', animationDelay: '0.3s' }}
+            />
+            <Image
+              src="/images/bird3.png"
+              alt="Bird 3"
+              width={45}
+              height={45}
+              className="absolute w-[65px] h-[65px] animate-[float-flipped_3s_ease-in-out_infinite]"
+              style={{ left: '0', top: '40px', animationDelay: '1.2s' }}
+            />
+          </div>
+        </ParallaxLayer>
+
+        {/* <ParallaxLayer offset={getOffset('road')} speed={0}>
+          <div className="absolute top-[-63vh] md:top-[-40vh] left-1/2 -translate-x-1/2 w-[170vw] md:w-[250vw] h-[175vh] md:h-[250vh]">
+            <Image
+              src="/images/road.png"
+              alt="Road"
+              fill
+              className={`object-contain ${screenSize === 'sm' ? 'scale-[1] sm:scale-[0.8]' : screenSize === 'md' ? 'scale-[1] sm:scale-[0.8]' : screenSize === 'lg' ? 'scale-[1] sm:scale-[0.8]' : screenSize === 'xl' ? 'scale-[1] sm:scale-[0.8]' : 'scale-[1]'} rotate-[20deg]`}
+            />
+          </div>
+        </ParallaxLayer> */}
+
+        <ParallaxLayer offset={getOffset('about-text')} speed={0}>
+          <div id="about" className="h-full w-full grid grid-cols-1 md:grid-cols-2 gap-8 p-12">
+            <div className="col-span-1 h-1/3 flex justify-center items-center">
+              <AboutSection />
+            </div>
+          </div>
+        </ParallaxLayer>
+
+        {/* <ParallaxLayer offset={getOffset('event1')} speed={0}>
+          <div id="event1">
+            <EventPreview
+              title='opening ceremony'
+              date={new Date().toISOString()}
+              location='Frances A. Cordova Recreational Sports Center'
+              description='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+              cardType={1}
+              popupType={1}
+              isActive={activeEventId === 1}
+              onEventClick={() => handleEventClick(1)}
+            />
+          </div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('event2')} speed={0}>
+          <div id="event2">
+            <EventPreview
+              title='activity name'
+              date={new Date().toISOString()}
+              location='Frances A. Cordova Recreational Sports Center'
+              description='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+              cardType={2}
+              popupType={2}
+              isActive={activeEventId === 2}
+              onEventClick={() => handleEventClick(2)}
+            />
+          </div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('event3')} speed={0}>
+          <div id="event3">
+            <EventPreview
+              title='activity name'
+              date={new Date().toISOString()}
+              location='Frances A. Cordova Recreational Sports Center'
+              description='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+              cardType={3}
+              popupType={2}
+              isActive={activeEventId === 3}
+              onEventClick={() => handleEventClick(3)}
+            />
+          </div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('event4')} speed={0}>
+          <div id="event4">
+            <EventPreview
+              title='activity name'
+              date={new Date().toISOString()}
+              location='Frances A. Cordova Recreational Sports Center'
+              description='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+              cardType={2}
+              popupType={2}
+              isActive={activeEventId === 4}
+              onEventClick={() => handleEventClick(4)}
+            />
+          </div>
+        </ParallaxLayer>
+        <ParallaxLayer offset={getOffset('event5')} speed={0}>
+          <div id="event5">
+            <EventPreview
+              title='activity name'
+              date={new Date().toISOString()}
+              location='Frances A. Cordova Recreational Sports Center'
+              description='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+              cardType={2}
+              popupType={1}
+              isActive={activeEventId === 5}
+              onEventClick={() => handleEventClick(5)}
+            />
+          </div>
+        </ParallaxLayer> */}
+
+        {/* Campfires layer */}
+        <ParallaxLayer offset={getOffset('campfires')} speed={0} style={{ zIndex: 5, pointerEvents: 'none' }}>
+          <div className="absolute -right-6 sm:-right-6 lg:-right-12">
+            <Image
+              src="/images/campfires.png"
+              alt="Tents"
+              width={50}
+              height={50}
+              className="w-[200px] h-[200px] sm:w-[250px] sm:h-[250px] md:w-[275px] md:h-[275px] lg:w-[350px] lg:h-[350px]"
+              priority
+            />
+          </div>
+        </ParallaxLayer>
+
+        {/* Background layer for Sponsors */}
+        <ParallaxLayer offset={getOffset('sponsors-background')} speed={0}>
+          <div id="sponsors" className='h-full w-full'>
+          </div>
+        </ParallaxLayer>
+
+        {/* Sponsors Sign Layer */}
+        <ParallaxLayer offset={getOffset('sponsors-sign')} speed={0} style={{ zIndex: 0 }}>
+          <div className='h-full w-full'>
+            <div className={`w-1/3 h-1/3`}>
+              <SponsorSign />
+            </div>
+          </div>
+        </ParallaxLayer>
+
+        {/* Sponsors Content Layer */}
+        <ParallaxLayer offset={getOffset('sponsors-content')} speed={0} style={{ zIndex: 10 }}>
+          <div className='h-full w-full'>
+            <div className={`w-1/3 h-1/3`}></div>
+
+            <div className="px-8 sm:px-10 md:px-12 lg:px-16 xl:px-20 max-w-[1600px] mx-auto">
+              <div className="flex flex-col gap-1 md:gap-2 lg:gap-4">
+                { /* <h3 className='text-4xl font-bold'>Coming Soon!</h3> */ }
+                {sponsors.map((sponsorRow, rowIndex) => (
+                  <div
+                    key={rowIndex}
+                    className={`flex justify-center items-center ${
+                      rowIndex === 0 ? 'gap-8 md:gap-16 lg:gap-20' :
+                      rowIndex === 1 ? 'gap-6 md:gap-14 lg:gap-16' :
+                      rowIndex === 2 ? 'gap-4 md:gap-12 lg:gap-14' :
+                      'gap-3 md:gap-8 lg:gap-12'}`}
                   >
-                    APPLY NOW!
-                  </span>
-                </a>
+                    {sponsorRow.map((sponsor, index) => (
+                      <SponsorCard
+                        key={index}
+                        sponsor={sponsor}
+                        size={rowIndex === 0 ? "xl" : rowIndex === 1 ? "lg" : rowIndex === 2 ? "md" : "sm"}
+                      />
+                    ))}
+                  </div>
+                ))}
               </div>
-            </section>
+            </div>
+          </div>
+        </ParallaxLayer>
 
-            {/* Footer Section */}
-            <section
-              id="footer"
-              className="absolute flex flex-col items-center justify-center w-full gap-8"
-              style={{ top: "1880vh", zIndex: 100, position: "absolute", backgroundColor: "transparent" }}
-            >
-              {/* Social Media Icons */}
-              <div className="flex flex-row gap-6">
-                <a
-                  href="https://www.instagram.com/boilermake/?hl=en"
-                  className="text-[#FFDE00] hover:text-[#FFE958] transition duration-300 ease-in-out"
-                  aria-label="Instagram"
-                  onMouseEnter={(e) => {
-                    const target = e.currentTarget as HTMLElement;
-                    target.style.textShadow = "0px 0px 15px #FFE958";
-                  }}
-                  onMouseLeave={(e) => {
-                    const target = e.currentTarget as HTMLElement;
-                    target.style.textShadow = "none";
-                  }}
-                >
-                  <i
-                    className="fab fa-instagram"
-                    style={{ fontSize: "1.75em" }}
-                  />
-                </a>
-                <a
-                  href="https://www.linkedin.com/company/boilermake/"
-                  className="text-[#FFDE00] hover:text-[#FFE958] transition duration-300 ease-in-out"
-                  aria-label="LinkedIn"
-                  onMouseEnter={(e) => {
-                    const target = e.currentTarget as HTMLElement;
-                    target.style.textShadow = "0px 0px 15px #FFE958";
-                  }}
-                  onMouseLeave={(e) => {
-                    const target = e.currentTarget as HTMLElement;
-                    target.style.textShadow = "none";
-                  }}
-                >
-                  <i
-                    className="fab fa-linkedin"
-                    style={{ fontSize: "1.75em" }}
-                  />
-                </a>
+        <ParallaxLayer offset={getOffset('footer')} speed={0}>
+          <div id="footer" className="flex flex-col justify-end h-full w-full">
+            <div className="animation_layer parallax" id="footer-background"></div>
+            <footer id='textblock-footer' className="relative z-10">
+              <div className='text-white'>
+                Created With 💛 By&nbsp;
+                <a href="/home">Boilermake</a>
               </div>
+            </footer>
+          </div>
+        </ParallaxLayer>
 
-              {/* Made with love text */}
-              <p
-                className="text-center text-white"
-                style={{
-                  fontFamily: "var(--font-geist-vf)",
-                  fontWeight: 300,
-                  fontSize: "clamp(14px, 1.5vw, 18px)",
-                  letterSpacing: "0.05em",
-                  color: "#FFFFFF",
-                  textShadow: "0px 0px 15px #FFDE00",
-                }}
-              >
-                Made with 💛 by the BoilerMake XIII team
-              </p>
-            </section>
-          </main>
-        </div>
-      </>
-    </TypingProvider>
+      </Parallax>
+    </div>
   );
 }
 

--- a/app/2025/styles.css
+++ b/app/2025/styles.css
@@ -1,0 +1,317 @@
+/* ===== 2025 PAGE STYLES (Parallax/Western Theme) ===== */
+/* This file is ONLY imported by the 2025 page to avoid any CSS conflicts */
+
+/* Root container - fills viewport for parallax */
+.page-2025 {
+  height: 100vh;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+/* Teams page */
+.page-2025 #teams-page {
+  background: linear-gradient(to top, #7AA689 0%, #C0E2F9 100%);
+  height: 450vh;
+}
+@media (max-width: 768px) {
+  .page-2025 #teams-page {
+    height: 400vh;
+  }
+}
+
+/* Hero */
+.page-2025 #hero {
+  background: linear-gradient(to bottom, #DDB47D 41%, #C5E1E6 96%);
+  height: 100vh;
+}
+@media (max-width: 768px) {
+  .page-2025 #hero {
+    height: 75vh;
+  }
+}
+
+/* About Background */
+.page-2025 #about-background {
+  background: linear-gradient(to bottom, #C5E1E6 0%, #C3E1ED 36%, #C0E2F9 100%);
+  height: 200vh;
+  position: relative;
+}
+@media (max-width: 768px) {
+  .page-2025 #about-background {
+    height: 100vh;
+  }
+}
+
+/* Schedule Section */
+.page-2025 #schedule {
+  background: linear-gradient(to top, #7AA689 0%, #C0E2F9 100%);
+  height: 200vh;
+}
+@media (max-width: 768px) {
+  .page-2025 #schedule {
+    height: 101vh;
+  }
+}
+
+/* FAQ Section */
+.page-2025 #faq {
+  background-color: #7AA689;
+  min-height: 101vh;
+  overflow-y: visible;
+}
+@media (max-width: 768px) {
+  .page-2025 #faq {
+    min-height: 76vh;
+    overflow-y: visible;
+  }
+}
+
+/* Sponsors Section */
+.page-2025 #sponsors {
+  background-color: #7AA689;
+  height: 150vh;
+}
+@media (max-width: 768px) {
+  .page-2025 #sponsors {
+    height: 200vh;
+  }
+}
+
+/* Footer */
+.page-2025 #footer {
+  background-color: #7AA689;
+  position: relative;
+  overflow: hidden;
+  margin-top: auto;
+}
+@media (max-width: 768px) {
+  .page-2025 #footer {
+    height: 50vh;
+  }
+}
+
+/* Text Blocks */
+.page-2025 #textblock-container {
+  width: 50%;
+  margin: 0 auto;
+  padding-top: 70px;
+}
+.page-2025 #about-container {
+  position: absolute;
+  bottom: 100px;
+  left: 100px;
+  width: 40%;
+  margin: 0;
+  text-align: left;
+  padding: 0;
+}
+.page-2025 #textblock-title {
+  color: #000000;
+  font-size: 35px;
+  font-weight: 600;
+  font-family: "Helvetica Neue";
+}
+.page-2025 #textblock-content {
+  color: #000000;
+  font-size: 20px;
+}
+.page-2025 #textblock-footer {
+  position: relative;
+  width: 100%;
+  padding-bottom: 20px;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: transparent;
+}
+.page-2025 #textblock-boilermake {
+  text-decoration: none;
+  color: #000000;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+/* Animation Styles (parallax layers) */
+.page-2025 .animation,
+.page-2025 .animation_layer {
+  height: 1000px;
+}
+@media (max-width: 768px) {
+  .page-2025 .animation,
+  .page-2025 .animation_layer {
+    height: 500px;
+  }
+}
+.page-2025 .animation {
+  display: block;
+  position: relative;
+  z-index: 10;
+}
+.page-2025 .animation_layer {
+  background-position: bottom center;
+  background-size: auto 1038px;
+  background-repeat: repeat-x;
+  width: 100%;
+  position: absolute;
+}
+.page-2025 .animation_layer.parallax {
+  position: fixed;
+}
+
+/* Cliff Section */
+.page-2025 #cliff {
+  position: absolute;
+  background: none;
+  background-size: cover;
+  background-blend-mode: normal;
+}
+.page-2025 #cliff::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 60%, #C5E1E6 100%);
+  pointer-events: none;
+}
+@media (max-width: 1024px) {
+  .page-2025 #cliff { height: 100%; }
+}
+@media (max-width: 768px) {
+  .page-2025 #cliff { height: 100%; }
+}
+
+/* Cloud Layers */
+.page-2025 #cloud1 {
+  position: absolute;
+  width: 60vw;
+  background: url("/images/cloud_transition_1.png") no-repeat center center;
+  background-size: contain;
+  left: 15%;
+  top: 10%;
+}
+.page-2025 #cloud2 {
+  position: absolute;
+  width: 90vw;
+  background: url("/images/cloud_transition_2.png") no-repeat center center;
+  background-size: contain;
+  left: -15%;
+}
+.page-2025 #cloud3 {
+  position: absolute;
+  width: 70vw;
+  background: url("/images/cloud_transition_3.png") no-repeat center center;
+  background-size: contain;
+  left: 40%;
+}
+.page-2025 #cloud4 {
+  position: absolute;
+  width: 40vw;
+  background: url("/images/cloud_transition_4.png") no-repeat center center;
+  background-size: contain;
+  left: 50%;
+  top: 10%;
+}
+.page-2025 #cloud5 {
+  position: absolute;
+  width: 25vw;
+  background: url("/images/cloud_transition_5.png") no-repeat center center;
+  background-size: contain;
+  left: 75%;
+  top: -12%;
+}
+@media (max-width: 768px) {
+  .page-2025 #cloud1 { top: 3%; }
+  .page-2025 #cloud4 { top: 4%; }
+  .page-2025 #cloud5 { top: -5%; }
+}
+
+/* Footer Background */
+.page-2025 #footer-background {
+  background: url("/images/footer_background.png") repeat-x;
+  height: 100%;
+  background-size: contain;
+  background-position: bottom;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  animation: page2025MoveBackground 30s linear infinite;
+}
+@keyframes page2025MoveBackground {
+  0% { background-position: 0 0; }
+  100% { background-position: 100vw 0; }
+}
+
+/* Mini Clouds */
+.page-2025 #mini-cloud-left {
+  position: absolute;
+  width: 40vw;
+  background: url("/images/cloud_transition_5.png") no-repeat center center;
+  background-size: contain;
+  left: 5%;
+}
+.page-2025 #mini-cloud-right {
+  position: absolute;
+  width: 40vw;
+  background: url("/images/cloud_transition_4.png") no-repeat center center;
+  opacity: 0.5;
+  background-size: contain;
+  left: 69%;
+}
+
+/* Sun */
+.page-2025 #sun {
+  position: absolute;
+  width: 45vw;
+  background: url("/images/sun.png") no-repeat center center;
+  background-size: contain;
+  left: -10%;
+}
+
+/* Statistics */
+.page-2025 #stat1, .page-2025 #stat2, .page-2025 #stat3 {
+  position: absolute;
+  background-size: 20%;
+  background-repeat: no-repeat;
+}
+.page-2025 #stat1 { left: 60%; transform: rotate(-6deg); }
+.page-2025 #stat2 { left: 45%; transform: translateX(-50%) rotate(-3deg); }
+.page-2025 #stat3 { left: 77%; transform: translateX(-50%) rotate(5deg); }
+@media (max-width: 768px) { .page-2025 #stat1 { left: 57%; } }
+
+/* Events */
+.page-2025 #event1 { position: absolute; left: 80%; }
+.page-2025 #event2 { position: absolute; left: 5%; }
+.page-2025 #event3 { position: absolute; left: 25%; }
+.page-2025 #event4 { position: absolute; left: 15%; }
+.page-2025 #event5 { position: absolute; left: 75%; }
+@media (max-width: 768px) {
+  .page-2025 #event1 { left: 80%; }
+  .page-2025 #event2 { left: 3%; }
+  .page-2025 #event3 { left: 25%; }
+  .page-2025 #event4 { left: 15%; }
+  .page-2025 #event5 { left: 77%; }
+}
+
+/* Activities */
+.page-2025 #activity1 { position: absolute; left: 65%; }
+.page-2025 #activity2 { position: absolute; left: 40%; }
+.page-2025 #activity3 { position: absolute; left: 10%; }
+.page-2025 #activity4 { position: absolute; left: 45%; }
+.page-2025 #activity5 { position: absolute; left: 65%; }
+.page-2025 #activity6 { position: absolute; left: 20%; }
+@media (max-width: 768px) {
+  .page-2025 #activity1 { left: 65%; }
+  .page-2025 #activity2 { left: 47%; }
+  .page-2025 #activity3 { left: 7%; }
+  .page-2025 #activity4 { left: 45%; }
+  .page-2025 #activity5 { left: 65%; }
+  .page-2025 #activity6 { left: 20%; }
+}

--- a/app/2026/page.tsx
+++ b/app/2026/page.tsx
@@ -1,0 +1,1170 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import Header from "@/components/Header";
+import HeroText from "@/components/HeroText";
+import AboutSection from "@/components/AboutSection";
+import ScheduleSign from "@/components/Signs/ScheduleSign";
+import Statistic from "@/components/Statistic";
+import FAQSign from "@/components/Signs/FAQSign";
+import SponsorSign from "@/components/Signs/SponsorSign";
+import SponsorCard from "@/components/SponsorCard";
+import FAQAccordian from "@/components/FAQAccordian";
+import ApplyButton from "@/components/ApplyButton";
+import Image from "next/image";
+import ActivityPreview from "@/components/Event/ActivityPreview";
+import BackgroundManager from "@/components/BackgroundManager";
+import { BackgroundScaleMode } from "@/components/BackgroundLayer";
+import { TypingProvider } from "@/context/TypingContext";
+
+const sponsors = [
+  [
+    // XL logos
+    {
+      name: "CAT",
+      logo: "/assets/sponsors/cat.png",
+      url: "https://www.caterpillar.com/",
+    },
+    {
+      name: "SFAB",
+      logo: "/assets/sponsors/SFAB.png",
+      url: "https://www.purdue.edu/sao/Fundraising/SOGA%20and%20SFAB.html",
+    },
+  ],
+  [
+    // LG logos
+  ],
+  [
+    // MD logos
+    {
+      name: "Purdue CS",
+      logo: "/assets/sponsors/PurdueCS.svg",
+      url: "https://www.cs.purdue.edu/",
+    },
+    {
+      name: "D.E. Shaw",
+      logo: "/assets/sponsors/deshaw.png",
+      url: "https://www.deshaw.com/",
+    },
+    {
+      name: "RCAC",
+      logo: "/assets/sponsors/RCAC_Logo.png",
+      url: "https://www.rcac.purdue.edu/",
+    },
+  ],
+  [
+    // SM logos
+    {
+      name: "CoE",
+      logo: "/assets/sponsors/coe.svg",
+      url: "https://engineering.purdue.edu/Engr",
+    },
+    {
+      name: "Roboflow",
+      logo: "/assets/sponsors/roboflow.png",
+      url: "https://roboflow.com/",
+    },
+    {
+      name: "Runpod",
+      logo: "/assets/sponsors/runpod_color.png",
+      url: "https://www.runpod.io/",
+    },
+    {
+      name: "Purdue Innovates",
+      logo: "/assets/sponsors/purdue_innovates.png",
+      url: "https://purdueinnovates.org/",
+    },
+  ],
+  [
+    {
+      name: "Klaviyo",
+      logo: "/assets/sponsors/klaviyo.png",
+      url: "https://www.klaviyo.com/",
+    },
+    {
+      name: "Blip",
+      logo: "/assets/sponsors/blip.png",
+      url: "https://www.blippayments.com/",
+    },
+    {
+      name: "Sync",
+      logo: "/assets/sponsors/sync.png",
+      url: "https://sync.so/",
+    },
+    {
+      name: "Modal",
+      logo: "/assets/sponsors/modal.svg",
+      url: "https://modal.com/",
+    },
+  ],
+  [
+    {
+      name: "Taco Bell",
+      logo: "/assets/sponsors/TacoBell.svg",
+      url: "https://www.tacobell.com/",
+    },
+    {
+      name: "Cartesia",
+      logo: "/assets/sponsors/cartesia.svg",
+      url: "https://www.cartesia.ai/",
+    },
+    {
+      name: "Warp",
+      logo: "/assets/sponsors/warp.png",
+      url: "https://www.warp.dev/",
+    },
+    {
+      name: "Wolfram",
+      logo: "/assets/sponsors/wolfram.png",
+      url: "https://www.wolfram.com/",
+    },
+  ],
+];
+
+const activities = [
+  {
+    title: "Opening Ceremony",
+    startDate: "2026-01-23T19:00:00",
+    endDate: "2026-01-23T21:00:00",
+    location: "Frances A. Cordova Recreational Sports Center",
+    description: "Introduction to BoilerMake, event logistics, and ice breaker activities!",
+  },
+  {
+    title: "Arcade",
+    startDate: "2026-01-24T21:00:00",
+    endDate: "2026-01-24T23:00:00",
+    location: "Frances A. Cordova Recreational Sports Center",
+    description: "Hackers can take a break and enjoy some arcade games, eat some snacks, socialize, and win prizes!",
+  },
+  {
+    title: "Hacking Ends",
+    startDate: "2026-01-25T09:00:00",
+    location: "Frances A. Cordova Recreational Sports Center",
+    description: "Hackers finish up their projects and submit online for judging before the deadline. They have time to prepare presentations and demos for the judges.",
+  },
+  {
+    title: "Judging",
+    startDate: "2026-01-25T10:00:00",
+    endDate: "2026-01-25T11:00:00",
+    location: "Frances A. Cordova Recreational Sports Center",
+    description: "A first round of judging where hackers are judged based on their submitted projects by our panel of judges.",
+  },
+  {
+    title: "Shark Tank",
+    startDate: "2026-01-25T13:30:00",
+    endDate: "2026-01-25T15:30:00",
+    location: "Frances A. Cordova Recreational Sports Center",
+    description: "The finalists present their projects to a panel of judges in a Shark Tank-style format for final evaluation. Awards and prizes are given out to the winners.",
+  },
+];
+
+const questions = [
+  {
+    question: "What is a Hackathon?",
+    answer:
+      "The BoilerMake hackathon is a 36-hour event where you can learn, build, and share a cool technology-based project! On top of your project work, you'll get free food, swag, and opportunities to win some of our $4,000 in prizes offered! We offer numerous events and activities as well to keep the fun going, and provide a platform to network with companies in the tech sector and other like-minded individuals from numerous backgrounds.",
+  },
+  {
+    question:
+      "Who can attend and how much experience do I need to participate?",
+    answer:
+      "Any undergraduate university student age 18 or older from any school or major can attend BoilerMake! No experience or technical background is required to participate, and we have mentors on site to assist with any technical needs. We also have unique and enriching experiences available to more skilled hackers, with special technologies and tech talks offered.",
+  },
+  {
+    question: "How does the application process work?",
+    answer:
+      "Once applications open, try to submit as soon as possible, make sure to write thoughtful responses in the application, and provide a good resume you want recruiters to see — these are sent to tech companies! Once your application is submitted, you can add your team members through the Teams portal — applicants in a Team will be preferred. After you are accepted through one of our acceptance rounds, you are REQUIRED to RSVP to attend the event. If you are Waitlisted, you are REQUIRED to RSVP to the waitlist to have a good chance at getting a spot. More details will be sent out based on your situation.",
+  },
+  {
+    question: "What projects can I make at BoilerMake?",
+    answer:
+      "You can build any project you want at BoilerMake! We have no strict project requirements, other than that it was built at the hackathon itself. Every year, we see a wide variety of technologies used and various applications for projects, and even see hardware-based projects — the possibilities are endless!",
+  },
+  {
+    question: "Does BoilerMake offer travel reimbursements?",
+    answer:
+      "Unfortunately, BoilerMake is not able to offer travel reimbursements at this time to those attending from other universities. We do provide all meals while you are at the hackathon, and offer parking to those who need it. The BoilerMake hackathon venue will be open during the entire duration of the hackathon, and there are many nearby locations which can offer housing over the course of the two nights.",
+  },
+];
+
+
+function App() {
+  const [activeEventId, setActiveEventId] = useState<number>(0);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [isUltraWide, setIsUltraWide] = useState(false);
+  // Initial positions for SSR/first render only
+  const [aboutCircleTop] = useState<string>("-20vh");
+  const [aboutCircleOpacity] = useState<number>(0.8);
+  const [faqCircleTop] = useState<string>("830vh");
+  const [faqCircleOpacity] = useState<number>(0.8);
+
+  useEffect(() => {
+    setIsLoaded(true);
+
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    const checkUltraWide = () => {
+      setIsUltraWide(window.innerWidth > 2559);
+    };
+
+    checkMobile();
+    checkUltraWide();
+    window.addEventListener("resize", checkMobile);
+
+    return () => {
+      window.removeEventListener("resize", checkMobile);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    gsap.registerPlugin(ScrollTrigger);
+
+    // Scope to this component so cleanup is airtight
+    const ctx = gsap.context(() => {
+      const aboutCircle = document.querySelector('[data-layer-id="about-circle"]') as HTMLElement | null;
+      const faqCircle   = document.querySelector('[data-layer-id="faq-circle"]')   as HTMLElement | null;
+
+      // Smooth, monotonic scrubs; GSAP re-computes on address bar changes via refresh
+      // ABOUT: from -20vh to 230vh  → delta 250vh
+      if (aboutCircle) {
+        gsap.set(aboutCircle, { y: 0, willChange: "transform" });
+        gsap.to(aboutCircle, {
+          // convert the same vh delta to px each refresh
+          y: () => window.innerHeight * (230 - (-20)) / 100,
+          ease: "none",
+          scrollTrigger: {
+            trigger: document.body,
+            start: 0,                                        // 0vh
+            end: () => window.innerHeight * 2.5,            // 250vh
+            scrub: true,
+            fastScrollEnd: true,
+            invalidateOnRefresh: true
+          }
+        });
+      }
+
+      // FAQ: stop when circle's center aligns with "Escape Reality" heading center
+      if (faqCircle) {
+        gsap.set(faqCircle, { y: 0, willChange: "transform", force3D: true });
+
+        const faqSection = document.getElementById("faq");
+        const contact    = document.getElementById("contact");
+        // try to grab the heading inside #contact; fallback to the section itself
+        const heading    = (contact?.querySelector("h1") as HTMLElement) || contact!;
+
+        const pageY = (el: HTMLElement) => el.getBoundingClientRect().top + window.scrollY;
+
+        // small knobs:
+        const startOffsetPx = 0;    // begin moving exactly when #faq hits viewport top; raise if you want a later start
+        const nudgePx       = 0;    // positive = stop a bit higher than exact center; negative = a bit lower
+
+        const compute = () => {
+          const baseTopPx    = parseFloat(getComputedStyle(faqCircle).top); // circle's CSS baseline (no transform)
+          const circleRect   = faqCircle.getBoundingClientRect();
+          const circleHalf   = circleRect.height / 2;
+
+          const startPx = faqSection ? pageY(faqSection) + startOffsetPx : window.scrollY;
+
+          const headingRect      = heading.getBoundingClientRect();
+          const headingCenterPx  = pageY(heading) + headingRect.height / 2;
+
+          // distance we need to translate so circle center == heading center (+ nudge)
+          const desiredY = Math.max(
+            0,
+            headingCenterPx - (baseTopPx + circleHalf) - nudgePx
+          );
+
+          // scroll span == movement distance so scrub maps 1:1
+          const endPx = startPx + desiredY;
+
+          return { startPx, endPx, desiredY };
+        };
+
+        // Build tween with dynamic, refresh-aware endpoints
+        const tween = gsap.to(faqCircle, {
+          y: () => compute().desiredY,
+          ease: "none",
+          scrollTrigger: {
+            trigger: document.body,
+            start: () => compute().startPx,
+            end:   () => compute().endPx,
+            scrub: true,
+            fastScrollEnd: true,
+            invalidateOnRefresh: true,
+            onRefresh: self => self.scroll(self.scroll()),
+            markers: false
+          }
+        });
+
+        // Helps with iOS up-scroll/address bar quirks
+        ScrollTrigger.normalizeScroll(true);
+      }
+
+      // Make sure ScrollTrigger measures correctly after content/fonts load
+      requestAnimationFrame(() => ScrollTrigger.refresh());
+    });
+
+    return () => {
+      ctx.revert(); // kills tweens and ScrollTriggers created in this effect
+    };
+  }, []);
+
+  useEffect(() => {
+    // Run after hydration + next paint
+    const nudge = () => {
+      // Dispatch synthetic scroll/resize to observers
+      window.dispatchEvent(new Event("resize"));
+      window.dispatchEvent(new Event("scroll"));
+      // Tiny scroll jiggle to guarantee intersection recalculation
+      const x = window.scrollX,
+        y = window.scrollY;
+      window.scrollTo(x, y + 1);
+      window.scrollTo(x, y);
+    };
+
+    // Initial nudge
+    const t1 = setTimeout(nudge, 0);
+    // Nudge again after images/styles settle
+    const t2 = setTimeout(nudge, 250);
+
+    // Also nudge when page becomes visible (reloads from bfcache, etc.)
+    const onVis = () => {
+      if (document.visibilityState === "visible") {
+        nudge();
+      }
+    };
+    document.addEventListener("visibilitychange", onVis);
+
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      document.removeEventListener("visibilitychange", onVis);
+    };
+  }, []);
+
+  const handleEventClick = (id: number) => {
+    if (id === activeEventId) {
+      setActiveEventId(0);
+    } else {
+      setActiveEventId(id);
+    }
+  };
+
+  // Background layer configuration with responsive heights
+  const backgroundLayers = [
+    {
+      id: "solid-bg-color",
+      imageUrl: "/this/is/a/fake/image.png", // This will fail to load, showing fallback
+      zIndex: -100,
+      opacity: 1,
+      fallbackColor: "#2A2627", // This should show as the background color
+      priority: true, // Always load immediately
+    },
+    {
+      id: "background-comb",
+      imageUrl: "/images/bg-comb.svg",
+      position: "absolute" as const,
+      zIndex: -50,
+      opacity: 1,
+      top: 0,
+      blendMode: "normal",
+      useIntrinsicHeight: false,
+      height: "500vh",
+      width: "100%",
+      fallbackColor: "transparent",
+      priority: true,
+    },
+    {
+      id: "stars-left",
+      imageUrl: "/images/stars-left.png",
+      position: "absolute" as const,
+      zIndex: -50,
+      opacity: 0.8,
+      top: "80vh",
+      left: "-35%",
+      height: "30vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "stars-right",
+      imageUrl: "/images/stars-right.png",
+      position: "absolute" as const,
+      zIndex: -99,
+      opacity: 0.8,
+      top: "60vh", // A bit higher than stars-left (80vh)
+      left: "35%", // Positioned on the right side (100% + 35% overhang = 135%)
+      height: "30vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "about-circle",
+      imageUrl: "/images/about-circle.png",
+      position: "absolute" as const,
+      zIndex: -80,
+      opacity: aboutCircleOpacity,
+      top: aboutCircleTop,
+      left: "0%",
+      height: "150vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "stars-about",
+      imageUrl: "/images/stars-about.png",
+      position: "absolute" as const,
+      zIndex: -81,
+      opacity: 0.8, // Increase visibility
+      top: "255vh", // Start at the top of the viewport
+      left: "25%",
+      height: "30vh", // Covers the viewport while scrolling
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true,
+    },
+    {
+      id: "about-accent",
+      imageUrl: isUltraWide ? "/this/is/fake" : "/images/about-accent.svg",
+      position: "absolute" as const,
+      zIndex: -70,
+      opacity: 1,
+      top: "250vh",
+      left: "0%",
+      height: "30vh",
+      width: "100%",
+      scaleMode: "fill" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+    {
+      id: "stars-schedule",
+      imageUrl: "/images/stars-schedule.png",
+      position: "absolute" as const,
+      zIndex: -51,
+      opacity: 0.8,
+      top: "400vh", // A bit higher than stars-left (80vh)
+      left: "-30%", // Positioned on the right side (100% + 35% overhang = 135%)
+      height: "40vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "corridor-1",
+      imageUrl: "/images/corridor-1.png",
+      position: "absolute" as const,
+      zIndex: -50,
+      opacity: 1,
+      top: "440vh",
+      left: "calc(50% - 125px)",
+      width: "250px",
+      height: "210vh",
+      scaleMode: "fill" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      useIntrinsicHeight: false,
+    },
+    {
+      id: "ringed-red-planet",
+      imageUrl: "/images/ringed-red-planet.png",
+      position: "absolute" as const,
+      zIndex: -50,
+      opacity: 1,
+      top: "470vh",
+      left: "75vw",
+      width: "25vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+    {
+      id: "schedule-grid",
+      imageUrl: "/images/schedule-grid.png",
+      position: "absolute" as const,
+      zIndex: -70,
+      opacity: 1,
+      top: "470vh",
+      left: "0%",
+      width: "100%",
+      height: "260vh",
+      useIntrinsicHeight: false,
+      scaleMode: "cover" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+    {
+      id: "white-star",
+      imageUrl: "/images/white-star.png",
+      position: "absolute" as const,
+      zIndex: -40,
+      opacity: 1,
+      top: "525vh",
+      left: "20vw",
+      width: "20vw",
+      height: "20vh",
+      scaleMode: "fill" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+    {
+      id: "blue-red-planet",
+      imageUrl: "/images/blue-red-planet.png",
+      position: "absolute" as const,
+      zIndex: -40,
+      opacity: 1,
+      top: "600vh",
+      left: "60vw",
+      width: "20vw",
+      height: "20vh",
+      scaleMode: "fill" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+    {
+      id: "faq-gradient",
+      imageUrl: "/images/faq-gradient.png",
+      position: "absolute" as const,
+      zIndex: -50,
+      opacity: 1,
+      top: "700vh",
+      left: "0%",
+      width: "100vw",
+      height: "1200vh",
+      useIntrinsicHeight: false,
+      scaleMode: "fill" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true,
+    },
+    {
+      id: "stars-faq",
+      imageUrl: "/images/stars-faq.png",
+      position: "absolute" as const,
+      zIndex: 0,
+      opacity: 0.8,
+      top: "830vh", // A bit higher than stars-left (80vh)
+      left: "-35%", // Positioned on the right side (100% + 35% overhang = 135%)
+      height: "40vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "faq-circle",
+      imageUrl: "/images/faq-circle.png",
+      position: "absolute" as const,
+      zIndex: -99,
+      opacity: faqCircleOpacity,
+      top: faqCircleTop,
+      left: "0%",
+      height: "150vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "stars-faq2",
+      imageUrl: "/images/stars-faq2.png",
+      position: "absolute" as const,
+      zIndex: 0,
+      opacity: 0.8,
+      top: "960vh", // A bit higher than stars-left (80vh)
+      left: "35%", // Positioned on the right side (100% + 35% overhang = 135%)
+      height: "40vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "faq-accent",
+      imageUrl: "/images/faq_paths.svg",
+      position: "absolute" as const,
+      zIndex: -30,
+      opacity: 1,
+      top: "840vh",
+      left: "0vw",
+      width: "100vw",
+      height: "20vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+    {
+      id: "stars-sponsors",
+      imageUrl: "/images/stars-sponsors.png",
+      position: "absolute" as const,
+      zIndex: 0,
+      opacity: 0.8, // Increase visibility
+      top: "1040vh", // Start at the top of the viewport
+      left: "35%",
+      height: "40vh", // Covers the viewport while scrolling
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true,
+    },
+    // {
+    //   id: "planet-1",
+    //   imageUrl: "/images/planet1.png",
+    //   position: "absolute" as const,
+    //   zIndex: -39,
+    //   opacity: 1,
+    //   top: "1506vh",
+    //   left: "40vw",
+    //   // width: "100vw",
+    //   height: "20vw",
+    //   scaleMode: "contain" as BackgroundScaleMode,
+    //   blendMode: "normal",
+    //   fallbackColor: "transparent",
+    // },
+    // {
+    //   id: "planet2",
+    //   imageUrl: "/images/planet2.png",
+    //   position: "absolute" as const,
+    //   zIndex: -39,
+    //   opacity: 1,
+    //   top: "1415vh",
+    //   left: "47vw",
+    //   // width: "100vw",
+    //   height: "20vh",
+    //   scaleMode: "contain" as BackgroundScaleMode,
+    //   blendMode: "normal",
+    //   fallbackColor: "transparent",
+    // },
+    // {
+    //   id: "planet3",
+    //   imageUrl: "/images/planet3.png",
+    //   position: "absolute" as const,
+    //   zIndex: -39,
+    //   opacity: 1,
+    //   top: "1480vh",
+    //   left: "-40vw",
+    //   // width: "100vw",
+    //   height: "20vh",
+    //   scaleMode: "contain" as BackgroundScaleMode,
+    //   blendMode: "normal",
+    //   fallbackColor: "transparent",
+    // },
+    // {
+    //   id: "planet4",
+    //   imageUrl: "/images/planet4.png",
+    //   position: "absolute" as const,
+    //   zIndex: -39,
+    //   opacity: 1,
+    //   top: "1450vh",
+    //   left: "1vw",
+    //   // width: "100vw",
+    //   height: "20vh",
+    //   scaleMode: "contain" as BackgroundScaleMode,
+    //   blendMode: "normal",
+    //   fallbackColor: "transparent",
+    // },
+    // {
+    //   id: "ringed-planet",
+    //   imageUrl: "/images/ring-planet.png",
+    //   position: "absolute" as const,
+    //   zIndex: -39,
+    //   opacity: 1,
+    //   top: "1350vh",
+    //   left: "-30vw",
+    //   height: "20vh",
+    //   scaleMode: "contain" as BackgroundScaleMode,
+    //   blendMode: "normal",
+    //   fallbackColor: "transparent",
+    // },
+    {
+      id: "orbits",
+      imageUrl: "/images/solar_sys.svg",
+      position: "absolute" as const,
+      zIndex: -40,
+      opacity: 1,
+      top: "1350vh",
+      left: "0vw",
+      width: "100vw",
+      height: "200vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+    {
+      id: "stars-message",
+      imageUrl: "/images/stars-faq.png",
+      position: "absolute" as const,
+      zIndex: 0,
+      opacity: 0.8,
+      top: "1600vh", // A bit higher than stars-left (80vh)
+      left: "-35%", // Positioned on the right side (100% + 35% overhang = 135%)
+      height: "40vh",
+      scaleMode: "contain" as BackgroundScaleMode,
+      backgroundPosition: "center",
+      blendMode: "normal",
+      fallbackColor: "transparent",
+      priority: true, // Always load immediately
+    },
+    {
+      id: "footer-accent",
+      imageUrl: "/images/footer-accent-high-res.png",
+      position: "absolute" as const,
+      zIndex: -80,
+      opacity: 1,
+      top: "1630vh",
+      left: "-40vw",
+      width: "150vw",
+      height: "120vh",
+      useIntrinsicHeight: false,
+      scaleMode: "fill" as BackgroundScaleMode,
+      blendMode: "normal",
+      fallbackColor: "transparent",
+    },
+  ];
+
+  return (
+    <TypingProvider>
+      <>
+        <link
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+          rel="stylesheet"
+        />
+        <div className="App font-dosis">
+          {/* Background Manager - replaces parallax background system */}
+          <BackgroundManager
+            layers={backgroundLayers}
+            globalFallbackColor="#C5E1E6"
+          />
+
+          {/* Header - updated to work without parallax */}
+          <Header />
+
+          {/* Main content container with CSS Grid layout */}
+          <main
+            className="w-full main-content"
+            style={{ height: "1900vh", overflow: "hidden" }}
+          >
+            {/* Hero Section */}
+            <section id="hero" className="hero-section">
+              <div
+                className="hero-content "
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  textAlign: "center",
+                  width: "100%",
+                }}
+              >
+                <div className="hero-text">
+                  <h2
+                    className="text-center mb-6"
+                    style={{
+                      fontFamily: "var(--font-futura-cyrillic)",
+                      fontWeight: 100,
+                      fontSize: "clamp(18px, 3.5vw, 28px)",
+                      lineHeight: "100%",
+                      letterSpacing: "0.1em",
+                      color: "#FFFFFF",
+                      textAlign: "center",
+                      width: "100%",
+                      marginLeft: "auto",
+                      marginRight: "auto",
+                      filter: "drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))",
+                    }}
+                  >
+                    23 - 25 January 2026
+                    <span
+                      className="text-white"
+                      style={{ animation: "blink 1s step-end infinite" }}
+                    >
+                      _
+                    </span>
+                  </h2>
+                  <h1
+                    className="text-center mb-12"
+                    style={{
+                      fontFamily: "var(--font-disket-mono)",
+                      fontWeight: 400,
+                      fontSize: "clamp(32px, 8vw, 80px)",
+                      lineHeight: "100%",
+                      letterSpacing: "0.1em",
+                      color: "#FFE958",
+                      textShadow: "0px 0px 15px #FFDE00",
+                    }}
+                  >
+                    {" "}
+                    BOILERMAKE XIII{" "}
+                  </h1>
+                  <link
+                    rel="icon"
+                    href="assets/favicon.ico"
+                    type="image/x-icon"
+                  />
+                </div>
+                <div
+                  className="hero-buttons"
+                  style={{ 
+                    display: "flex",
+                    flexDirection: "row",
+                    gap: "1.5rem",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    flexWrap: "wrap"
+                  }}
+                >
+                  <ApplyButton
+                    text="APPLY NOW!"
+                    link="https://boilermake-apply.web.app"
+                    size="large"
+                    variant="hero"
+                    className="mr-0"
+                  />
+                  <ApplyButton
+                    text="INTEREST FORM"
+                    link="https://docs.google.com/forms/d/e/1FAIpQLScaVyVFmm3Jwn1225SjUPCInKD9-MLZhxIRtQT8o4y1HAxs_g/viewform"
+                    size="large"
+                    variant="hero"
+                    className="mr-0"
+                  />
+                  <ApplyButton
+                    text="MENTOR FORM"
+                    link="https://docs.google.com/forms/d/e/1FAIpQLScmpc_zMGpQGUZy5vFkCTbkh-3oG5WMKx1eDES1ziDDSOqA4w/viewform"
+                    size="large"
+                    variant="hero"
+                    className="mr-0"
+                  />
+                </div>
+              </div>
+            </section>
+            {/* About Section */}
+            <section
+              id="about"
+              className="w-[80vw] lg:w-[60vw] flex items-center justify-center absolute"
+              style={{ top: "270vh" }}
+            >
+              <AboutSection />
+            </section>
+
+            {/* Schedule Section */}
+            <section
+              id="schedule"
+              className="w-full flex items-center justify-center absolute"
+              style={{ top: "410vh", paddingTop: "8rem" }}
+            >
+              <div className="w-full max-w-7xl mx-auto px-4">
+                <div
+                  className="text-center absolute left-1/2 -translate-x-1/2 z-10 pointer-events-none"
+                  style={{ top: "8rem" }}
+                >
+                  <div
+                    style={{
+                      fontFamily: "var(--font-disket-mono)",
+                      fontWeight: 400,
+                      fontSize: "clamp(32px, 8vw, 60px)",
+                      lineHeight: "100%",
+                      letterSpacing: "0.1em",
+                      color: "#FFE958",
+                      textShadow: "0px 0px 15px #FFDE00",
+                    }}
+                  >
+                    Schedule
+                    <span style={{ animation: "blink 1s infinite" }}>_</span>
+                  </div>
+                </div>
+
+                <div
+                  className="schedule-activities w-full relative mt-12 md:mt-32"
+                  style={{ marginTop: "12rem" }}
+                >
+                  {activities.map((activity, index) => {
+                    const isLeft = index % 2 === 0;
+                    return (
+                      <div
+                        key={`activity${index + 1}`}
+                        className={`
+                          absolute
+                          transition-transform duration-500
+                            ${
+                              isLeft
+                                ? "left-0 -translate-x-[-2%] md:-translate-x-[-5%] lg:-translate-x-[-3%] xl:-translate-x-[1%] min-[1340px]:-translate-x-[6%] min-[1400px]:-translate-x-[10%] min-[1470px]:-translate-x-[17%] 2xl:-translate-x-[20%]"
+                                : "right-0 translate-x-[-2%] md:translate-x-[-6%] lg:translate-x-[-3%] xl:translate-x-[1%] min-[1340px]:translate-x-[5%] min-[1400px]:translate-x-[10%] min-[1470px]:translate-x-[17%] 2xl:translate-x-[20%]"
+                            }
+                        `}
+                        style={{
+                          top: `${index * 33}vh`,
+                        }}
+                      >
+                        <ActivityPreview
+                          title={activity.title}
+                          startDate={activity.startDate}
+                          endDate={activity.endDate || ""}
+                          location={activity.location}
+                          description={activity.description}
+                          isActive={activeEventId === index + 1}
+                          onEventClick={() => handleEventClick(index + 1)}
+                          size="large"
+                          popup="left"
+                          align={isLeft ? "left" : "right"}
+                          activityId={index + 1}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </section>
+
+            {/* FAQ Section */}
+            <section
+              id="faq"
+              className="w-full flex items-start justify-center absolute overflow-x-hidden"
+              style={{
+                top: "840vh",
+                paddingTop: "8rem",
+                paddingBottom: "8rem",
+              }}
+            >
+              {/* Absolute header like the others */}
+              <div
+                className="text-center absolute left-1/2 -translate-x-1/2 z-[100] pointer-events-none"
+                style={{ top: "8rem" }}
+              >
+                <div
+                  style={{
+                    fontFamily: "var(--font-disket-mono)",
+                    fontWeight: 400,
+                    fontSize: "clamp(32px, 8vw, 60px)",
+                    lineHeight: "100%",
+                    letterSpacing: "0.1em",
+                    color: "#FFE958",
+                    textShadow: "0px 0px 15px #FFDE00",
+                  }}
+                >
+                  FAQ<span style={{ animation: "blink 1s infinite" }}>_</span>
+                </div>
+              </div>
+
+              {/* Actual accordion content */}
+              <div
+                className="faq-sign w-full flex justify-center pb-8 overflow-x-hidden"
+                style={{ marginTop: "12rem" }}
+              >
+                <FAQAccordian questions={questions} />
+              </div>
+            </section>
+
+{/* Sponsors Section */}
+            <section
+              id="sponsors"
+              className="absolute flex flex-col items-center justify-center py-20 px-8 w-full"
+              style={{ top: "1050vh" }}
+            >
+              {/* Main Content Container - All content centered vertically */}
+              <div className="flex flex-col items-center justify-center gap-12 max-w-4xl">
+                {/* Message text */}
+                <h1
+                  className="text-center"
+                  style={{
+                    fontFamily: "var(--font-disket-mono)",
+                    fontWeight: 400,
+                    fontSize: "clamp(32px, 8vw, 60px)",
+                    lineHeight: "100%",
+                    letterSpacing: "0.1em",
+                    color: "#FFE958",
+                    textShadow: "0px 0px 15px #FFDE00",
+                  }}
+                >
+                  SPONSORS
+                  <span style={{ animation: "blink 1s infinite" }}>_</span>
+                </h1>
+
+                  <h2
+                    className="text-center mb-6"
+                    style={{
+                      
+                      fontWeight: 400,
+                      fontSize: "clamp(18px, 3.5vw, 28px)",
+                      lineHeight: "100%",
+                      letterSpacing: "0.1em",
+                      textAlign: "center",
+                      width: "100%",
+                      marginLeft: "auto",
+                      marginRight: "auto",
+                      filter: "drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))",
+                      fontFamily: "var(--font-disket-mono)",
+                      color: "#FFE958",
+                      textShadow: "0px 0px 15px #FFDE00",
+                    }}
+                  >
+                    [coming soon]
+                    <span
+                      className="text-white"
+                      // style={{ animation: "blink 1s step-end infinite" }}
+                    >
+                      {/* _ */}
+                    </span>
+                  </h2>
+                {/* Button */}
+                <a
+                  // href="https://docs.google.com/forms/d/e/1FAIpQLScaVyVFmm3Jwn1225SjUPCInKD9-MLZhxIRtQT8o4y1HAxs_g/viewform"
+                  href="/past"
+                  className="inline-block px-12 py-4 border-2 border-white text-white uppercase tracking-wider transition-all duration-300 hover:bg-black/20"
+                  style={{
+                    fontFamily: "var(--font-futura-cyrillic)",
+                    fontWeight: 500,
+                    fontSize: "clamp(14px, 2vw, 18px)",
+                    letterSpacing: "0.15em",
+                  }}
+                >
+                  <span
+                    style={{
+                      borderBottom: "2px solid #FFFFFF",
+                      paddingBottom: "4px",
+                    }}
+                  >
+                    IN THE PAST
+                  </span>
+                </a>
+              </div>
+            </section>
+
+            {/* Contact/Message Section */}
+            <section
+              id="contact"
+              className="absolute flex flex-col items-center justify-center py-20 px-8 w-full"
+              style={{ top: "1540vh" }}
+            >
+              {/* Main Content Container - All content centered vertically */}
+              <div className="flex flex-col items-center justify-center gap-12 max-w-4xl">
+                {/* Message text */}
+                <h1
+                  className="text-center"
+                  style={{
+                    fontFamily: "var(--font-disket-mono)",
+                    fontWeight: 400,
+                    fontSize: "clamp(32px, 8vw, 60px)",
+                    lineHeight: "100%",
+                    letterSpacing: "0.1em",
+                    color: "#FFE958",
+                    textShadow: "0px 0px 15px #FFDE00",
+                  }}
+                >
+                  Escape Reality
+                  <span style={{ animation: "blink 1s infinite" }}>_</span>
+                </h1>
+
+                {/* Button */}
+                <a
+                  // href="https://docs.google.com/forms/d/e/1FAIpQLScaVyVFmm3Jwn1225SjUPCInKD9-MLZhxIRtQT8o4y1HAxs_g/viewform"
+                  href="https://boilermake-apply.web.app"
+                  className="inline-block px-12 py-4 border-2 border-white text-white uppercase tracking-wider transition-all duration-300 hover:bg-black/20"
+                  style={{
+                    fontFamily: "var(--font-futura-cyrillic)",
+                    fontWeight: 500,
+                    fontSize: "clamp(14px, 2vw, 18px)",
+                    letterSpacing: "0.15em",
+                  }}
+                >
+                  <span
+                    style={{
+                      borderBottom: "2px solid #FFFFFF",
+                      paddingBottom: "4px",
+                    }}
+                  >
+                    APPLY NOW!
+                  </span>
+                </a>
+              </div>
+            </section>
+
+            {/* Footer Section */}
+            <section
+              id="footer"
+              className="absolute flex flex-col items-center justify-center w-full gap-8"
+              style={{ top: "1880vh", zIndex: 100, position: "absolute", backgroundColor: "transparent" }}
+            >
+              {/* Social Media Icons */}
+              <div className="flex flex-row gap-6">
+                <a
+                  href="https://www.instagram.com/boilermake/?hl=en"
+                  className="text-[#FFDE00] hover:text-[#FFE958] transition duration-300 ease-in-out"
+                  aria-label="Instagram"
+                  onMouseEnter={(e) => {
+                    const target = e.currentTarget as HTMLElement;
+                    target.style.textShadow = "0px 0px 15px #FFE958";
+                  }}
+                  onMouseLeave={(e) => {
+                    const target = e.currentTarget as HTMLElement;
+                    target.style.textShadow = "none";
+                  }}
+                >
+                  <i
+                    className="fab fa-instagram"
+                    style={{ fontSize: "1.75em" }}
+                  />
+                </a>
+                <a
+                  href="https://www.linkedin.com/company/boilermake/"
+                  className="text-[#FFDE00] hover:text-[#FFE958] transition duration-300 ease-in-out"
+                  aria-label="LinkedIn"
+                  onMouseEnter={(e) => {
+                    const target = e.currentTarget as HTMLElement;
+                    target.style.textShadow = "0px 0px 15px #FFE958";
+                  }}
+                  onMouseLeave={(e) => {
+                    const target = e.currentTarget as HTMLElement;
+                    target.style.textShadow = "none";
+                  }}
+                >
+                  <i
+                    className="fab fa-linkedin"
+                    style={{ fontSize: "1.75em" }}
+                  />
+                </a>
+              </div>
+
+              {/* Made with love text */}
+              <p
+                className="text-center text-white"
+                style={{
+                  fontFamily: "var(--font-geist-vf)",
+                  fontWeight: 300,
+                  fontSize: "clamp(14px, 1.5vw, 18px)",
+                  letterSpacing: "0.05em",
+                  color: "#FFFFFF",
+                  textShadow: "0px 0px 15px #FFDE00",
+                }}
+              >
+                Made with 💛 by the BoilerMake XIII team
+              </p>
+            </section>
+          </main>
+        </div>
+      </>
+    </TypingProvider>
+  );
+}
+
+export default App;

--- a/components/AboutSection2025.tsx
+++ b/components/AboutSection2025.tsx
@@ -1,0 +1,17 @@
+/**
+ * AboutSection.tsx
+ * Component will be used to show the about section on the landing page, with the title 'About' and a description of boilermake.
+ * @AshokSaravanan222
+ * 09-15-2024
+ */
+
+export default function AboutSection() {
+    return (
+        <div className="container mx-auto text-left">
+            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-semibold font-title pb-2 sm:pb-3 md:pb-4 lg:pb-6 text-black">About</h1>
+            <div>
+            <p className="text-xs sm:text-lg md:text-lg lg:text-xl max-w-prose text-black">BoilerMake is Purdue University's premier hackathon, bringing together over 500 students from numerous universities and majors to compete in 36 hours of hacking for $4000+ in prizes. Designed for hackers of all levels, BoilerMake provides unique and valuable experiences regardless of skill level -- you can participate in fun activities, win cool prizes, get free swag and food, and most importantly, have a whole lot of fun! It's also a great opportunity to network with large companies in industry and develop new skills. BoilerMake XII will take place February 21-23, 2025. BoilerMake is also an MLH partner meaning we adhere to their <a href="https://hackp.ac/coc" target="_blank" className="z-1000" style={{textDecoration: "underline"}}>Code of Conduct</a></p>
+            </div>
+        </div>
+    )
+}

--- a/components/ApplyButton2025.tsx
+++ b/components/ApplyButton2025.tsx
@@ -1,0 +1,36 @@
+/**
+ * ApplyButton.tsx
+ * Will be used to display the apply button, with a prop for size (small, medium, large)
+ * @AshokSaravanan222
+ * 09-15-2024
+ */
+
+import React from 'react';
+
+type ApplyButtonProps = {
+    text: string;
+    link: string;
+    size: 'small' | 'medium' | 'large' | 'xsmall';
+    className?: string;
+}
+
+export default function ApplyButton({text, link, size, className }: ApplyButtonProps) {
+    // Define classes for each size
+    const sizeClasses = {
+        small: 'py-2 px-2 text-xs rounded-full', // Larger border-radius for small
+        medium: 'py-3 px-4 text-base rounded-full', // Larger border-radius for medium
+        large: 'py-4 px-6 text-3xl rounded-2xl', // Moderate border-radius for large
+        xsmall: 'py-1 px-1 text-[10px] rounded-full', // Smallest border-radius for xsmall
+    };
+
+    return (
+        <a href={link} target='_blank' rel='noreferrer'>
+            {/* text-[#DDB47D] was original color*/}
+            <button
+                className={`bg-white shadow-md text-[#C6A270] font-body font-extrabold hover:shadow-xl transition-shadow duration-300 ${sizeClasses[size]} ${className}`}
+            >
+                {text}
+            </button>
+        </a>
+    );
+}

--- a/components/Event/ActivityPreview2025.tsx
+++ b/components/Event/ActivityPreview2025.tsx
@@ -1,0 +1,92 @@
+/**
+ * ActivityPreview.tsx
+ * This component is used to display a preview of an event,
+ * @AshokSaravanan222
+ * 12-24-2024
+ */
+
+import { useState } from "react";
+import EventPopup from "./EventPopup";
+import Image from "next/image";
+import ActivitySign from "../Signs/ActivitySign2025";
+
+type ActivityPreviewProps = {
+    title: string;
+    startDate: string;
+    endDate: string;
+    location: string;
+    description: string;
+    isActive: boolean;
+    onEventClick: () => void;
+    size: 'small' | 'medium' | 'large' | 'xlarge';
+    popup: 'left' | 'right'
+  };
+
+
+const ActivityPreview: React.FC<ActivityPreviewProps> = ({
+    title,
+    startDate,
+    endDate,
+    location,
+    description,
+    isActive,
+    onEventClick,
+    size,
+    popup
+  }) => {
+    const [isPopupVisible, setIsPopupVisible] = useState(false);
+
+    const handleCircleClick = () => {
+        onEventClick();
+    };
+
+    // Show popup only when this event is active
+    const showPopup = isActive;
+
+    // Determine popup position based on size
+    const popupPosition = popup === 'right'
+      ? 'left-full -ml-8' // Position to the right
+      : size === 'xlarge'
+      ? '-left-full ml-16 sm:ml-32 md:ml-44 lg:ml-56' // Position to the left
+      : size === 'medium'
+      ? '-left-full -ml-5 sm:-ml-0 md:-ml-0 lg:-ml-0' // Position to the left
+      : size === 'large' ?
+      '-left-full -ml-16 sm:-ml-24 md:-ml-28 lg:ml-36'
+      : '-left-full -ml-32 sm:-ml-40 md:-ml-32 lg:-ml-20'; // Position to the left
+
+    // Handlers for hover events
+    const handleMouseEnter = () => {
+      if (!isActive) setIsPopupVisible(true);
+    };
+
+    const handleMouseLeave = () => {
+      if (!isActive) setIsPopupVisible(false);
+    };
+
+    return (
+      <div className="relative cursor-pointer" onClick={handleCircleClick}>
+        <div
+          className={`flex flex-col items-center gap-4`}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <ActivitySign title={title} startDate={startDate} size={size} />
+
+          {/* Popup */}
+          {(showPopup && isPopupVisible) && (
+            <div className={`absolute top-1/2 -translate-y-1/2 ${popupPosition} z-50`}>
+              <EventPopup
+                title={title}
+                startDate={startDate}
+                endDate={endDate}
+                location={location}
+                description={description}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    );
+};
+
+export default ActivityPreview;

--- a/components/FAQAccordian2025.tsx
+++ b/components/FAQAccordian2025.tsx
@@ -1,0 +1,54 @@
+/**
+ * FAQAccordian.tsx
+ * Will be used to display the Frequently Asked Questions that hackers might have
+ * @AshokSaravanan222
+ * 09-15-2024
+ */
+import React, { useState } from 'react';
+import Image from 'next/image';
+
+type FAQAccordianProps = {
+  questions: { question: string, answer: string }[];
+};
+
+export default function FAQAccordian({ questions }: FAQAccordianProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const toggleAccordion = (index: number) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <div id="accordion-collapse" className="space-y-1">
+      {questions.map((faq, index) => (
+        <div key={index} className="max-w-full">
+          <h2 className="text-black">
+            <button
+              type="button"
+              className={`flex text-[10px] sm:text-lg md:text-lg lg:text-xl items-center justify-between p-2 md:p-3 lg:p-5 font-medium font-subtitle border border-b-0 bg-[#E1E5E7] ${index === 0 ? "rounded-t-xl" : index === questions.length - 1 && openIndex !== index ? "rounded-b-xl" : "" } hover:bg-gray-100 gap-3 w-full`}
+              onClick={() => toggleAccordion(index)}
+              aria-expanded={openIndex === index}
+              aria-controls={`accordion-collapse-body-${index}`}
+            >
+              <span className="text-black">{faq.question}</span>
+              <Image
+                src={"/images/pin.png"}
+                alt="Pin Icon"
+                className={`w-4 md:w-6 lg:w-8 transition-transform duration-200 ${openIndex === index ? 'rotate-90' : ''}`}
+                width={32}
+                height={32}
+              />
+            </button>
+          </h2>
+          <div
+            id={`accordion-collapse-body-${index}`}
+            className={`${openIndex === index ? 'block' : 'hidden'} p-2 sm:p-3 md:p-3 lg:p-5 border border-white bg-[#E1E5E7] rounded-b-xl w-full text-[10px] sm:text-lg md:text-lg lg:text-xl text-left`}
+            aria-labelledby={`accordion-collapse-heading-${index}`}
+          >
+            <p className="mb-2 text-black">{faq.answer}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/Header2025.tsx
+++ b/components/Header2025.tsx
@@ -1,0 +1,107 @@
+/**
+ * Header2025.tsx
+ * Original header for the 2025 parallax landing page
+ */
+
+import React from 'react';
+import ApplyButton from './ApplyButton';
+import Image from 'next/image';
+import { IParallax } from '@react-spring/parallax';
+import { LAYER_OFFSETS, ScreenSize } from '@/utils/parallaxOffset';
+
+type HeaderProps = {
+    screenSize: ScreenSize;
+    parallaxRef?: React.RefObject<IParallax>;
+};
+
+export default function Header2025({ screenSize, parallaxRef }: HeaderProps) {
+    const handleNavigation = (section: string) => {
+        const offset = LAYER_OFFSETS[section][screenSize]
+        // Check if we're on the main page
+        if (window.location.pathname === '/2025') {
+            // If we are, just scroll
+            if (parallaxRef?.current) {
+                parallaxRef.current.scrollTo(offset);
+            }
+        } else {
+            // If we're not, navigate to main page with hash parameter
+            window.location.href = `/2025?scroll=${offset}`;
+        }
+    };
+
+    return (
+        <header className="w-full p-4 fixed top-0 z-50">
+            <div className="flex justify-between items-center text-white">
+                {/* Logo */}
+                <a href="/2025">
+                    <Image
+                        src={"/images/logo.png"}
+                        alt="Boilermake Logo"
+                        width={100}
+                        height={100}
+                        className="w-[50px] h-[50px] md:w-[100px] md:h-[100px] object-contain"
+                    />
+                </a>
+
+                {/* Spacer */}
+                <div className="flex-grow"></div>
+
+                <div className="flex">
+                    <nav className="flex space-x-2 sm:space-x-4 md:space-x-12 px-4 md:px-12">
+                        <ul className="flex space-x-4 sm:space-x-8 md:space-x-12">
+                            <li>
+                                <button
+                                    onClick={() => handleNavigation('stat3')}
+                                    className="hover:text-amber-600 transition-all duration-300 font-subtitle text-xs md:text-xl font-bold drop-shadow-[0_2px_2px_rgba(0,0,0,0.3)]"
+                                >
+                                    About
+                                </button>
+                            </li>
+                            <li>
+                                <a
+                                    href="/about-us"
+                                    className="hover:text-amber-600 transition-all duration-300 font-subtitle text-xs md:text-xl font-bold drop-shadow-[0_2px_2px_rgba(0,0,0,0.3)] truncate"
+                                >
+                                    About Us
+                                </a>
+                            </li>
+                            <li>
+                                <button
+                                    onClick={() => handleNavigation('schedule-section')}
+                                    className="hover:text-amber-600 transition-all duration-300 font-subtitle text-xs md:text-xl font-bold drop-shadow-[0_2px_2px_rgba(0,0,0,0.3)]"
+                                >
+                                    Schedule
+                                </button>
+                            </li>
+                            <li>
+                                <button
+                                    onClick={() => handleNavigation('faq-sign')}
+                                    className="hover:text-amber-600 transition-all duration-300 font-subtitle text-xs md:text-xl font-bold drop-shadow-[0_2px_2px_rgba(0,0,0,0.3)]"
+                                >
+                                    FAQ
+                                </button>
+                            </li>
+                            <li>
+                                <button
+                                    onClick={() => handleNavigation('sponsors-sign')}
+                                    className="hover:text-amber-600 transition-all duration-300 font-subtitle text-xs md:text-xl font-bold drop-shadow-[0_2px_2px_rgba(0,0,0,0.3)]"
+                                >
+                                    Sponsors
+                                </button>
+                            </li>
+                        </ul>
+                    </nav>
+                    <div className="sm:block md:hidden">
+                        <ApplyButton text='Apply Now!' link='https://boilermake-apply.web.app' size={"xsmall"} />
+                    </div>
+                    <div className="hidden md:block lg:hidden">
+                        <ApplyButton text='Apply Now!' link='https://boilermake-apply.web.app' size={"small"} />
+                    </div>
+                    <div className="hidden lg:block">
+                        <ApplyButton text='Apply Now!' link='https://boilermake-apply.web.app' size={"medium"} />
+                    </div>
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/components/Signs/ActivitySign2025.tsx
+++ b/components/Signs/ActivitySign2025.tsx
@@ -1,0 +1,78 @@
+/**
+ * ActivitySign.tsx
+ * Component used to show an activity, with time and description
+ */
+
+import Image from "next/image";
+
+type ActivitySignProps = {
+    title: string;
+    startDate: string;  // Changed from time: string
+    size: 'small' | 'medium' | 'large' | 'xlarge';
+}
+
+const sizeMap = {
+    'small': 'w-[100px] h-[100px] sm:w-[125px] sm:h-[125px] md:w-[200px] md:h-[200px] lg:w-[275px] lg:h-[275px] xl:w-[300px] xl:h-[300px]',
+    'medium': 'w-[175px] h-[175px] sm:w-[225px] sm:h-[225px] md:w-[300px] md:h-[300px] lg:w-[350px] lg:h-[350px] xl:w-[400px] xl:h-[400px]',
+    'large': 'w-[200px] h-[200px] sm:w-[275px] sm:h-[275px] md:w-[350px] md:h-[350px] lg:w-[450px] lg:h-[450px] xl:w-[500px] xl:h-[500px]',
+    'xlarge': 'w-[250px] h-[250px] sm:w-[325px] sm:h-[350px] md:w-[450px] md:h-[450px] lg:w-[550px] lg:h-[550px] xl:w-[600px] xl:h-[600px]'
+}
+
+const textOffset = {
+    'small': 'pt-[23px] sm:pt-[30px] md:pt-[50px] lg:pt-[65px] xl:pt-[75px]',
+    'medium': 'pt-[45px] sm:pt-[55px] md:pt-[80px] lg:pt-[100px] xl:pt-[120px]',
+    'large': 'pt-[55px] sm:pt-[80px] md:pt-[110px] lg:pt-[120px] xl:pt-[140px]',
+    'xlarge': 'pt-[60px] sm:pt-[90px] md:pt-[120px] lg:pt-[150px] xl:pt-[170px]'
+}
+
+const timeSize = {
+    'small': 'text-[8px] sm:text-[10px] md:text-sm lg:text-lg',
+    'medium': 'text-base sm:text-base md:text-lg lg:text-xl',
+    'large': 'text-lg sm:text-xl md:text-2xl lg:text-3xl',
+    'xlarge': 'text-xl sm:text-2xl md:text-3xl lg:text-4xl'
+}
+
+const titleSize = {
+    'small': 'text-[10px] sm:text-[12px] md:text-sm lg:text-base',
+    'medium': 'text-base sm:text-base md:text-lg lg:text-xl',
+    'large': 'text-lg sm:text-xl md:text-2xl lg:text-3xl',
+    'xlarge': 'text-2xl sm:text-3xl md:text-4xl lg:text-5xl'
+}
+
+const textMargin = {
+    'small': 'mt-0 sm:mt-0 md:mt-1',
+    'medium': 'mt-0 sm:mt-0 md:mt-2',
+    'large': 'mt-1 sm:mt-1 md:mt-3',
+    'xlarge': 'mt-1 sm:mt-2 md:mt-4'
+}
+
+export default function ActivitySign({ title, startDate, size }: ActivitySignProps) {
+    const date = new Date(startDate);
+    const weekday = date.toLocaleString([], { weekday: 'short' });
+    const time = date.toLocaleString([], { hour: '2-digit', minute: '2-digit' });
+
+    return (
+        <div className="relative w-full h-full flex items-center justify-cente hover:-translate-y-1 transition">
+            <div className={`relative w-${sizeMap[size]}  h-${sizeMap[size]}`}>
+                <Image src="/images/activity_sign.png" alt="Activity Card" className={sizeMap[size]} width={0} height={0} sizes="100vh" />
+                <div
+                    className={`absolute inset-0 flex flex-col items-center select-none ${textOffset[size]}`}
+                >
+                    <div className={`text-white ${timeSize[size]} font-semibold font-title`}>
+                        <span>{weekday}</span>
+                        <span className="mx-1">·</span>
+                        <span>{time}</span>
+                    </div>
+                    <p className={`text-white ${titleSize[size]} font-semibold font-title leading-none ${textMargin[size]}`}>
+                        {title.split(' ').length === 2 ? (
+                            <>
+                                {title.split(' ')[0]}<br />
+                                {title.split(' ')[1]}
+                            </>
+                        ) : title}
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/components/Signs/ScheduleSign2025.tsx
+++ b/components/Signs/ScheduleSign2025.tsx
@@ -1,0 +1,27 @@
+/**
+ * ScheduleSign.tsx
+ * This component is used to display the schedule sign on the landing page.
+ * @AshokSaravanan222
+ * 09-15-2024
+ */
+import Image from 'next/image';
+
+export default function ScheduleSign() {
+    return (
+        <div className="w-full h-full">
+            <div className="relative w-full h-auto flex items-center justify-center max-w-4xl mx-auto">
+                <Image
+                    src={"/images/highway_sign.png"}
+                    alt="Schedule Sign"
+                    className="w-full h-full object-contain max-w-4xl max-h-[450px]"
+                    width={0}
+                    height={0}
+                />
+                <div className='absolute z-10 flex flex-col items-center justify-center'>
+                    <h1 className="text-xl font-semibold text-white font-title mt-2 md:mt-8"></h1>
+                    <a href="/schedule.pdf" target="_blank" rel="noopener noreferrer" className="text-center text-[#06A77D] text-sm md:text-md lg:text-xl pt-14 sm:pt-16 md:pt-20 lg:pt-24 xl:pt-28 font-semibold hover:underline">click for more!</a>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/components/SponsorCard2025.tsx
+++ b/components/SponsorCard2025.tsx
@@ -1,0 +1,74 @@
+/**
+ * SponsorCard.tsx
+ * This will be used to display each of the sponsors on the landing page, with their logo and a link to their website.
+ * @AshokSaravanan222
+ * 09-15-2024
+ */
+
+import Image, { StaticImageData } from "next/image";
+import React, { useEffect, useRef, useState } from "react"
+
+type SponsorCardProps = {
+    sponsor: {
+        name: string; // for alt text
+        logo: string;
+        url: string;
+    };
+    size?: 'sm' | 'md' | 'lg' | 'xl';
+}
+
+const sizeClasses = {
+    'sm': 'w-[125px] sm:w-[150px] md:w-[175px] lg:w-[225px]',
+    'md': 'w-[150px] sm:w-[200px] md:w-[225px] lg:w-[275px]',
+    'lg': 'w-[200px] sm:w-[275px] md:w-[325px] lg:w-[375px]',
+    'xl': 'w-[300px] sm:w-[375px] md:w-[450px] lg:w-[550px]'
+};
+
+export default function SponsorCard({ sponsor, size = 'md' }: SponsorCardProps) {
+    const [isVisible, setIsVisible] = useState(false);
+    const cardRef = useRef<HTMLAnchorElement>(null);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setIsVisible(true);
+                    observer.unobserve(entry.target);
+                }
+            },
+            {
+                threshold: 0.1,
+                rootMargin: '50px'
+            }
+        );
+
+        if (cardRef.current) {
+            observer.observe(cardRef.current);
+        }
+
+        return () => {
+            if (cardRef.current) {
+                observer.unobserve(cardRef.current);
+            }
+        };
+    }, []);
+
+    return (
+        <a 
+            href={sponsor.url} 
+            target="_blank" 
+            rel="noreferrer" 
+            ref={cardRef}
+            className={`transition-all duration-700 hover:scale-110 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}
+        >
+            <Image 
+                src={sponsor.logo} 
+                alt={sponsor.name} 
+                className={`${sizeClasses[size]} object-contain`}
+                width={0}
+                height={0}
+                sizes="100vw"
+            />
+        </a>
+    )
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@react-spring/parallax": "^9.7.5",
+    "@react-spring/web": "^9.7.5",
     "gsap": "^3.13.0",
     "next": "^15.1.2",
     "react": "^18",

--- a/utils/parallaxOffset.ts
+++ b/utils/parallaxOffset.ts
@@ -1,0 +1,300 @@
+// Define screen breakpoint types
+export type ScreenSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+// Define page counts for different screen sizes
+// export const PAGES_BY_SCREEN: Record<ScreenSize, number> = {
+//   'sm': 4,  // mobile (will be same as 'md')
+//   'md': 4.5,     // tablet (will be same as 'sm')
+//   'lg': 6.0,   // desktop (will be same as 'xl')
+//   'xl': 7,   // large desktop (will be same as 'lg')
+//   '2xl': 7   // extra large desktop (will be same as 'lg')
+// };
+
+// COPIED FOR the "coming soon" TEXT
+export const PAGES_BY_SCREEN: Record<ScreenSize, number> = {
+  'sm': 4.25,  // mobile (will be same as 'md')
+  'md': 4.8,     // tablet (will be same as 'sm')
+  'lg': 6.0,   // desktop (will be same as 'xl')
+  'xl': 7.2,   // large desktop (will be same as 'lg')
+  '2xl': 7.2   // extra large desktop (will be same as 'lg')
+};
+
+// Define offsets for each parallax layer by screen size
+export const LAYER_OFFSETS: Record<string, Record<ScreenSize, number>> = {
+  'cliff': {
+    'sm': 0,
+    'md': 0,
+    'lg': 0.1,
+    'xl': 0.05,
+    '2xl': 0
+  },
+  'about-background': {
+    'sm': 0.55,
+    'md': 0.55,
+    'lg': 0.5,
+    'xl': 0.5,
+    '2xl': 0.5
+  },
+  'hero': {
+    'sm': 0,
+    'md': 0,
+    'lg': 0,
+    'xl': 0,
+    '2xl': 0
+  },
+  'hero-text': {
+    'sm': 0.1,
+    'md': 0.1,
+    'lg': 0.1,
+    'xl': 0.1,
+    '2xl': 0.1
+  },
+  'apply': {
+    'sm': 0.4,
+    'md': 0.1,
+    'lg': 0.25,
+    'xl': 0.1,
+    '2xl': 0.1
+  },
+  'sun': {
+    'sm': 0.75,
+    'md': 0.8,
+    'lg': 0.8,
+    'xl': 0.9,
+    '2xl': 0.95
+  },
+  'cloud2': {
+    'sm': 0.6,
+    'md': 0.65,
+    'lg': 0.5,
+    'xl': 0.7,
+    '2xl': 0.75
+  },
+  'cloud4': {
+    'sm': 0.6,
+    'md': 0.65,
+    'lg': 0.5,
+    'xl': 0.7,
+    '2xl': 0.75
+  },
+  'cloud5': {
+    'sm': 0.6,
+    'md': 0.65,
+    'lg': 0.5,
+    'xl': 0.7,
+    '2xl': 0.75
+  },
+  'cloud3': {
+    'sm': 0.6,
+    'md': 0.65,
+    'lg': 0.5,
+    'xl': 0.7,
+    '2xl': 0.75
+  },
+  'cloud1': {
+    'sm': 0.6,
+    'md': 0.65,
+    'lg': 0.5,
+    'xl': 0.7,
+    '2xl': 0.75
+  },
+  'mini-cloud-left': {
+    'sm': 0.8,
+    'md': 0.9,
+    'lg': 0.9,
+    'xl': 0.9,
+    '2xl': 1.0
+  },
+  'mini-cloud-right': {
+    'sm': 0.85,
+    'md': 0.97,
+    'lg': 0.97,
+    'xl': 1.05,
+    '2xl': 1.1
+  },
+  'stat1': {
+    'sm': 0.99,
+    'md': 1.0,
+    'lg': 1.25,
+    'xl': 1.5,
+    '2xl': 1.55
+  },
+  'stat2': {
+    'sm': 0.99,
+    'md': 0.95,
+    'lg': 1.15,
+    'xl': 1.35,
+    '2xl': 1.4
+  },
+  'stat3': {
+    'sm': 0.99,
+    'md': 0.97,
+    'lg': 1.1,
+    'xl': 1.25,
+    '2xl': 1.3
+  },
+  'faq-background': {
+    'sm': 2.1,
+    'md': 2.4,
+    'lg': 3.25,
+    'xl': 3.75,
+    '2xl': 3.75
+  },
+  'faq-sign': {
+    'sm': 2.1,
+    'md': 2.33,
+    'lg': 3.2,
+    'xl': 3.8,
+    '2xl': 3.8
+  },
+  'faq-accordion': {
+    'sm': 2.23,
+    'md': 2.4,
+    'lg': 3.25,
+    'xl': 3.75,
+    '2xl': 3.75
+  },
+  'schedule-background': {
+    'sm': 1.5,
+    'md': 1.5,
+    'lg': 1.82,
+    'xl': 2.0,
+    '2xl': 2.0
+  },
+  'schedule-section': {
+    'sm': 1.4,
+    'md': 1.4,
+    'lg': 1.85,
+    'xl': 2.0,
+    '2xl': 2.0
+  },
+  'windyroad': {
+    'sm': 1.5,
+    'md': 1.55,
+    'lg': 2.12,
+    'xl': 2.3,
+    '2xl': 2.3
+  },
+  'road': {
+    'sm': 1.55,
+    'md': 1.55,
+    'lg': 2.3,
+    'xl': 2.3,
+    '2xl': 2.3
+  },
+  'about-text': {
+    'sm': 1.05,
+    'md': 1.05,
+    'lg': 1.45,
+    'xl': 1.6,
+    '2xl': 1.65
+  },
+  'birds-about': {
+    'sm': 1.05,
+    'md': 1.05,
+    'lg': 1.45,
+    'xl': 1.6,
+    '2xl': 1.65
+  },
+  'birds-schedule': {
+    'sm': 1.5,
+    'md': 1.5,
+    'lg': 1.82,
+    'xl': 2.0,
+    '2xl': 2.0
+  },
+  'tents': {
+    'sm': 1.7,
+    'md': 1.75,
+    'lg': 2.3,
+    'xl': 2.55,
+    '2xl': 2.6
+  },
+  'event1': {
+    'sm': 1.33,
+    'md': 1.33,
+    'lg': 2.2,
+    'xl': 2.2,
+    '2xl': 2.2
+  },
+  'event2': {
+    'sm': 1.47,
+    'md': 1.47,
+    'lg': 2.6,
+    'xl': 2.6,
+    '2xl': 2.6
+  },
+  'event3': {
+    'sm': 1.73,
+    'md': 1.73,
+    'lg': 3.00,
+    'xl': 3.00,
+    '2xl': 3.00
+  },
+  'event4': {
+    'sm': 1.87,
+    'md': 1.87,
+    'lg': 3.30,
+    'xl': 3.30,
+    '2xl': 3.30
+  },
+  'event5': {
+    'sm': 1.98,
+    'md': 1.98,
+    'lg': 3.6,
+    'xl': 3.6,
+    '2xl': 3.6
+  },
+  'tumbleweed': {
+    'sm': 2.2,
+    'md': 2.3,
+    'lg': 3.1,
+    'xl': 3.3,
+    '2xl': 3.5
+  },
+  'campfires': {
+    'sm': 2.7,
+    'md': 3.0,
+    'lg': 3.9,
+    'xl': 4.6,
+    '2xl': 4.6
+  },
+  'sponsors-background': {
+    'sm': 2.85,
+    'md': 3.1,
+    'lg': 4.0,
+    'xl': 4.75,
+    '2xl': 4.75
+  },
+  'sponsors-sign': {
+    'sm': 2.85,
+    'md': 3.1,
+    'lg': 4.0,
+    'xl': 4.75,
+    '2xl': 4.75
+  },
+  'sponsors-content': {
+    'sm': 2.8,
+    'md': 3.1,
+    'lg': 4.0,
+    'xl': 4.75,
+    '2xl': 4.75
+  },
+  // original footer for sponsors, the one below this is for the coming soon text
+  /*
+   'footer': {
+     'sm': 4.65,
+     'md': 5.0,
+     'lg': 6.0,
+     'xl': 7.0,
+     '2xl': 8.0
+   },
+   */
+   'footer': {
+    'sm': 3.75,
+    'md': 4.3,
+    'lg': 5.2,
+    'xl': 6.2,
+    '2xl': 6.2
+  }, 
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,15 +43,15 @@
   resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz"
   integrity sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==
 
-"@img/sharp-libvips-linux-arm@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz"
-  integrity sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==
-
 "@img/sharp-libvips-linux-arm64@1.2.3":
   version "1.2.3"
   resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz"
   integrity sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==
+
+"@img/sharp-libvips-linux-arm@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz"
+  integrity sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==
 
 "@img/sharp-libvips-linux-ppc64@1.2.3":
   version "1.2.3"
@@ -78,19 +78,19 @@
   resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz"
   integrity sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==
 
-"@img/sharp-linux-arm@0.34.4":
-  version "0.34.4"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz"
-  integrity sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm" "1.2.3"
-
 "@img/sharp-linux-arm64@0.34.4":
   version "0.34.4"
   resolved "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz"
   integrity sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==
   optionalDependencies:
     "@img/sharp-libvips-linux-arm64" "1.2.3"
+
+"@img/sharp-linux-arm@0.34.4":
+  version "0.34.4"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz"
+  integrity sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.2.3"
 
 "@img/sharp-linux-ppc64@0.34.4":
   version "0.34.4"
@@ -246,7 +246,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -263,6 +263,59 @@
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@react-spring/animated@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.5.tgz#eb0373aaf99b879736b380c2829312dae3b05f28"
+  integrity sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==
+  dependencies:
+    "@react-spring/shared" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
+
+"@react-spring/core@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.5.tgz#72159079f52c1c12813d78b52d4f17c0bf6411f7"
+  integrity sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==
+  dependencies:
+    "@react-spring/animated" "~9.7.5"
+    "@react-spring/shared" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
+
+"@react-spring/parallax@^9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/parallax/-/parallax-9.7.5.tgz#28c7498546595282b5baea02ffb8c0777f8c91ee"
+  integrity sha512-9MP4D4YmQ7Oxeyzh2DPjPvNfXUhwQQS4LmSY9j01aDEzHKcgCGYgCFh1eX8Tc5JAyZWJDEKX9tUUzMg7XY91IA==
+  dependencies:
+    "@react-spring/shared" "~9.7.5"
+    "@react-spring/web" "~9.7.5"
+
+"@react-spring/rafz@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/rafz/-/rafz-9.7.5.tgz#ee7959676e7b5d6a3813e8c17d5e50df98b95df9"
+  integrity sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==
+
+"@react-spring/shared@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.5.tgz#6d513622df6ad750bbbd4dedb4ca0a653ec92073"
+  integrity sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==
+  dependencies:
+    "@react-spring/rafz" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
+
+"@react-spring/types@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.5.tgz#e5dd180f3ed985b44fd2cd2f32aa9203752ef3e8"
+  integrity sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==
+
+"@react-spring/web@^9.7.5", "@react-spring/web@~9.7.5":
+  version "9.7.5"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.5.tgz#7d7782560b3a6fb9066b52824690da738605de80"
+  integrity sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==
+  dependencies:
+    "@react-spring/animated" "~9.7.5"
+    "@react-spring/core" "~9.7.5"
+    "@react-spring/shared" "~9.7.5"
+    "@react-spring/types" "~9.7.5"
 
 "@swc/helpers@0.5.15":
   version "0.5.15"
@@ -513,7 +566,7 @@ function-bind@^1.1.2:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -526,13 +579,6 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
-
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
 
 glob@^10.3.10:
   version "10.4.5"
@@ -807,15 +853,6 @@ postcss-value-parser@^4.0.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8, postcss@^8.0.0, postcss@^8.2.14, postcss@^8.4.21, postcss@^8.4.47, postcss@>=8.0.9:
-  version "8.4.49"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz"
-  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.1.1"
-    source-map-js "^1.2.1"
-
 postcss@8.4.31:
   version "8.4.31"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
@@ -824,6 +861,15 @@ postcss@8.4.31:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8, postcss@^8.4.47:
+  version "8.4.49"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz"
+  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -837,7 +883,7 @@ react-curved-text@^3.0.1:
   dependencies:
     svg-path-commander "1.0.5"
 
-react-dom@^18, "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@>=18.0.0:
+react-dom@^18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -845,7 +891,7 @@ react-dom@^18, "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", re
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react@^18, "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^18.3.1, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=18.0.0:
+react@^18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
## Summary
- Restores the original BoilerMake XII parallax/western theme at `/2025` (from commit `3314498` with real sponsor data, activities, FAQ)
- Moves the current space-themed BoilerMake XIII page from `/2025` to `/2026` — exact copy, no modifications
- Root page (`/`), `/past`, and all other routes are completely untouched

## Approach
- Created dedicated `*2025.tsx` component copies to avoid conflicts with current components
- All 2025-specific CSS is in a separate `app/2025/styles.css` file scoped under `.page-2025` — `globals.css` is **not modified**
- Added `@react-spring/parallax@^9.7.5` and `@react-spring/web@^9.7.5` for the parallax page

## Test plan
- [ ] Verify `/2026` matches current production `boilermake.org/2025` (HTML verified identical)
- [ ] Verify `/2025` shows the original western/parallax theme with clouds, sun, cliff, sponsors, FAQ, schedule
- [ ] Verify `/` (root) is unchanged from production
- [ ] Verify `/past` is unchanged from production
- [ ] Verify no CSS bleed between pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)